### PR TITLE
Rename IsUnusedLink() method to IsDeleted()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/390
+Your prepared branch: issue-390-5e4626de
+Your prepared working directory: /tmp/gh-issue-solver-1757576102655
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/390
-Your prepared branch: issue-390-5e4626de
-Your prepared working directory: /tmp/gh-issue-solver-1757576102655
-
-Proceed.

--- a/cpp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.h
+++ b/cpp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.h
@@ -868,7 +868,7 @@ namespace Platform::Data::Doublets::Memory::Split::Generic
                 _indexMemory.UsedCapacity(_indexMemory.UsedCapacity() - LinkIndexPartSizeInBytes);
                 // Убираем все связи, находящиеся в списке свободных в конце файла, до тех пор, пока не дойдём до первой существующей связи
                 // Позволяет оптимизировать количество выделенных связей (AllocatedLinks)
-                while ((this->GetHeaderReference().AllocatedLinks > LinkAddressType{0}) && this->IsUnusedLink(this->GetHeaderReference().AllocatedLinks))
+                while ((this->GetHeaderReference().AllocatedLinks > LinkAddressType{0}) && this->IsDeleted(this->GetHeaderReference().AllocatedLinks))
                 {
                     UnusedLinksListMethods->Detach(this->GetHeaderReference().AllocatedLinks);
                     --this->GetHeaderReference().AllocatedLinks;
@@ -881,7 +881,7 @@ namespace Platform::Data::Doublets::Memory::Split::Generic
         }
 
     public:
-        bool IsUnusedLink(LinkAddressType linkIndex) const
+        bool IsDeleted(LinkAddressType linkIndex) const
         {
             if (GetHeaderReference().FirstFreeLink != linkIndex) // May be this check is not needed
             {
@@ -900,7 +900,7 @@ namespace Platform::Data::Doublets::Memory::Split::Generic
         {
             return (linkAddress >= Constants.InternalReferencesRange.Minimum)
                 && (linkAddress <= this->GetHeaderReference().AllocatedLinks)
-                && !IsUnusedLink(linkAddress);
+                && !IsDeleted(linkAddress);
         }
 
     public:

--- a/cpp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.h
+++ b/cpp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.h
@@ -423,7 +423,7 @@
             {
                 --header.AllocatedLinks;
                 _memory.UsedCapacity(_memory.UsedCapacity() - LinkSizeInBytes);
-                while ((header.AllocatedLinks > LinkAddressType {}) && IsUnusedLink(header.AllocatedLinks))
+                while ((header.AllocatedLinks > LinkAddressType {}) && IsDeleted(header.AllocatedLinks))
                 {
                     _UnusedLinksListMethods->Detach(header.AllocatedLinks);
                     --header.AllocatedLinks;
@@ -461,10 +461,10 @@
             {
                 return false;
             }
-            return (linkAddress >= Constants.InternalReferencesRange.Minimum) && (linkAddress <= this->GetHeaderReference().AllocatedLinks) && !IsUnusedLink(linkAddress);
+            return (linkAddress >= Constants.InternalReferencesRange.Minimum) && (linkAddress <= this->GetHeaderReference().AllocatedLinks) && !IsDeleted(linkAddress);
         }
 
-        bool IsUnusedLink(LinkAddressType linkIndex) const
+        bool IsDeleted(LinkAddressType linkIndex) const
         {
             if (GetHeaderReference().FirstFreeLink != linkIndex)// May be this check is not needed
             {

--- a/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
@@ -748,7 +748,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
             _indexMemory.UsedCapacity -= LinkIndexPartSizeInBytes;
             // Убираем все связи, находящиеся в списке свободных в конце файла, до тех пор, пока не дойдём до первой существующей связи
             // Позволяет оптимизировать количество выделенных связей (AllocatedLinks)
-            while ((header.AllocatedLinks > GetZero()) && IsUnusedLink(linkIndex: header.AllocatedLinks))
+            while ((header.AllocatedLinks > GetZero()) && IsDeleted(linkIndex: header.AllocatedLinks))
             {
                 UnusedLinksListMethods.Detach(freeLink: header.AllocatedLinks);
                 header.AllocatedLinks = header.AllocatedLinks - TLinkAddress.One;
@@ -942,12 +942,12 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     protected virtual bool Exists(TLinkAddress link)
     {
-        return (link >= Constants.InternalReferencesRange.Minimum) && (link <= GetHeaderReference().AllocatedLinks) && !IsUnusedLink(linkIndex: link);
+        return (link >= Constants.InternalReferencesRange.Minimum) && (link <= GetHeaderReference().AllocatedLinks) && !IsDeleted(linkIndex: link);
     }
 
     /// <summary>
     ///     <para>
-    ///         Determines whether this instance is unused link.
+    ///         Determines whether this instance is deleted.
     ///     </para>
     ///     <para></para>
     /// </summary>
@@ -960,7 +960,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     ///     <para></para>
     /// </returns>
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-    protected virtual bool IsUnusedLink(TLinkAddress linkIndex)
+    protected virtual bool IsDeleted(TLinkAddress linkIndex)
     {
         if ((GetHeaderReference().FirstFreeLink != linkIndex)) // May be this check is not needed
         {

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
@@ -562,7 +562,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
                 _memory.UsedCapacity -= LinkSizeInBytes;
                 // Убираем все связи, находящиеся в списке свободных в конце файла, до тех пор, пока не дойдём до первой существующей связи
                 // Позволяет оптимизировать количество выделенных связей (AllocatedLinks)
-                while (GreaterThan(header.AllocatedLinks, GetZero()) && IsUnusedLink(header.AllocatedLinks))
+                while (GreaterThan(header.AllocatedLinks, GetZero()) && IsDeleted(header.AllocatedLinks))
                 {
                     UnusedLinksListMethods.Detach(header.AllocatedLinks);
                     header.AllocatedLinks = header.AllocatedLinks - TLinkAddress.One;
@@ -666,11 +666,11 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         protected virtual bool Exists(TLinkAddress link)
             => GreaterOrEqualThan(link, Constants.InternalReferencesRange.Minimum)
             && LessOrEqualThan(link, GetHeaderReference().AllocatedLinks)
-            && !IsUnusedLink(link);
+            && !IsDeleted(link);
 
         /// <summary>
         /// <para>
-        /// Determines whether this instance is unused link.
+        /// Determines whether this instance is deleted.
         /// </para>
         /// <para></para>
         /// </summary>
@@ -683,7 +683,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected virtual bool IsUnusedLink(TLinkAddress linkIndex)
+        protected virtual bool IsDeleted(TLinkAddress linkIndex)
         {
             if (!AreEqual(GetHeaderReference().FirstFreeLink, linkIndex)) // May be this check is not needed
             {


### PR DESCRIPTION
## Summary

This PR renames the `IsUnusedLink()` method to `IsDeleted()` to improve code clarity and semantics.

## Changes Made

- ✅ Renamed `IsUnusedLink()` method to `IsDeleted()` in both C# and C++ implementations
- ✅ Updated all references and usage of the method across the codebase
- ✅ Updated method documentation to reflect the new name and clearer semantics
- ✅ Verified changes compile successfully

## Rationale

As described in issue #390, "Unused Link" has two different meanings in this context:
- **Unused Link**: A link that is not used by any other link as source/target
- **Deleted Link**: A link that is marked as deleted

This rename makes the distinction clearer and improves code readability.

## Files Modified

### C# Files
- `csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs`
- `csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs`

### C++ Files  
- `cpp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.h`
- `cpp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.h`

## Test Results

✅ C# project builds successfully with no compilation errors

Fixes #390

🤖 Generated with [Claude Code](https://claude.ai/code)