### PR TITLE
Add explicit documentation for IsUnusedLink method explaining the free list mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/355
+Your prepared branch: issue-355-16463e62
+Your prepared working directory: /tmp/gh-issue-solver-1757592421552
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/355
-Your prepared branch: issue-355-16463e62
-Your prepared working directory: /tmp/gh-issue-solver-1757592421552
-
-Proceed.

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
@@ -672,6 +672,12 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para>
         /// Determines whether this instance is unused link.
         /// </para>
+        /// <para>
+        /// This method works correctly because when a link is deleted, it is not indexed using trees 
+        /// (hence SizeAsSource = 0), but it has Source field used as Previous element and Target field 
+        /// used as Next element in the doubly-linked list of free links. This dual usage of the same 
+        /// memory structure allows efficient free link management without additional storage overhead.
+        /// </para>
         /// <para></para>
         /// </summary>
         /// <param name="linkIndex">
@@ -682,12 +688,23 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para>The bool</para>
         /// <para></para>
         /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The condition (SizeAsSource == 0 AND Source != 0) identifies unused links because:
+        /// - SizeAsSource is set to default (0) when the link is removed from tree indexing
+        /// - Source remains non-zero as it serves as the "Previous" pointer in the free links list
+        /// - This pattern is unique to deleted links since active links either have SizeAsSource > 0 
+        ///   (when indexed in trees) or Source == 0 (when not used as source in any connections)
+        /// </para>
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected virtual bool IsUnusedLink(TLinkAddress linkIndex)
         {
             if (!AreEqual(GetHeaderReference().FirstFreeLink, linkIndex)) // May be this check is not needed
             {
                 ref var link = ref GetLinkReference(linkIndex);
+                // Check if link is in free list: SizeAsSource is reset to 0 when removed from indexing,
+                // but Source is non-zero as it serves as Previous pointer in the free links doubly-linked list
                 return AreEqual(link.SizeAsSource, default) && !AreEqual(link.Source, default);
             }
             else


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the `IsUnusedLink` method in `UnitedMemoryLinksBase.cs` to explain why the code works correctly.

## Problem
The original issue #355 pointed out that the logic in line 693 of the `IsUnusedLink` method needed a more explicit description of why it works correctly.

## Solution
Added detailed documentation explaining the key insight:

**When a link is deleted:**
- It is **not indexed using trees** (hence `SizeAsSource = 0`) 
- But it **reuses its memory structure** as part of a doubly-linked free list:
  - `Source` field serves as the "Previous" pointer
  - `Target` field serves as the "Next" pointer

**The condition `AreEqual(link.SizeAsSource, default) && !AreEqual(link.Source, default)` works because:**
- `SizeAsSource == 0`: Link is removed from tree indexing
- `Source != 0`: Link is part of the free list (Source serves as Previous pointer)
- This pattern is unique to deleted links since active links either have `SizeAsSource > 0` (when indexed) or `Source == 0` (when not used as source)

## Changes Made
1. Enhanced XML documentation with detailed explanation of the mechanism
2. Added comprehensive `<remarks>` section explaining each condition
3. Added inline comment explaining the specific logic of the condition

## Impact
- Improves code maintainability and understanding
- No functional changes - only documentation improvements
- Helps future developers understand this clever memory optimization

Fixes #355

🤖 Generated with [Claude Code](https://claude.ai/code)