### PR TITLE
Return continue constant on full scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/338
-Your prepared branch: issue-338-627b1af9
-Your prepared working directory: /tmp/gh-issue-solver-1757706111037
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/338
+Your prepared branch: issue-338-627b1af9
+Your prepared working directory: /tmp/gh-issue-solver-1757706111037
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/GenericLinksTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/GenericLinksTests.cs
@@ -38,6 +38,13 @@ namespace Platform.Data.Doublets.Tests
             Using<uint>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
             Using<ulong>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
         }
+
+        [Fact]
+        public static void FullScanReturnsContinueTest()
+        {
+            Using<uint>(links => links.TestFullScanReturnsContinue());
+            Using<ulong>(links => links.TestFullScanReturnsContinue());
+        }
         private static void Using<TLinkAddress>(Action<ILinks<TLinkAddress>> action) where TLinkAddress  : IUnsignedNumber<TLinkAddress> , IShiftOperators<TLinkAddress,int,TLinkAddress>, IBitwiseOperators<TLinkAddress,TLinkAddress,TLinkAddress>, IMinMaxValue<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
         {
             var unitedMemoryLinks = new UnitedMemoryLinks<TLinkAddress>(new HeapResizableDirectMemory());

--- a/csharp/Platform.Data.Doublets.Tests/SplitMemoryGenericLinksTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/SplitMemoryGenericLinksTests.cs
@@ -35,6 +35,13 @@ namespace Platform.Data.Doublets.Tests
             Using<uint>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
             Using<ulong>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
         }
+
+        [Fact]
+        public static void FullScanReturnsContinueTest()
+        {
+            Using<uint>(links => links.TestFullScanReturnsContinue());
+            Using<ulong>(links => links.TestFullScanReturnsContinue());
+        }
         private static void Using<TLinkAddress> (Action<ILinks<TLinkAddress>> action) where TLinkAddress : IUnsignedNumber<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
         {
             using (var dataMemory = new HeapResizableDirectMemory())

--- a/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
@@ -435,6 +435,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     {
         var constants = Constants;
         var @break = constants.Break;
+        var @continue = constants.Continue;
         if (restriction.Count == 0)
         {
             for (var link = GetOne(); (link <= GetHeaderReference().AllocatedLinks); link = link + TLinkAddress.One)
@@ -444,9 +445,8 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
                     return @break;
                 }
             }
-            return @break;
+            return @continue;
         }
-        var @continue = constants.Continue;
         var any = constants.Any;
         var index = this.GetIndex(link: restriction);
         if (restriction.Count == 1)

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
@@ -342,6 +342,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         {
             var constants = Constants;
             var @break = constants.Break;
+            var @continue = constants.Continue;
             if (restriction.Count == 0)
             {
                 for (var link = GetOne(); LessOrEqualThan(link, GetHeaderReference().AllocatedLinks); link = link + TLinkAddress.One)
@@ -351,9 +352,8 @@ namespace Platform.Data.Doublets.Memory.United.Generic
                         return @break;
                     }
                 }
-                return @break;
+                return @continue;
             }
-            var @continue = constants.Continue;
             var any = constants.Any;
             var index = this.GetIndex(restriction);
             if (restriction.Count == 1)

--- a/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs
@@ -380,5 +380,43 @@ namespace Platform.Data.Doublets.Tests
                 links.Delete(link);
             }
         }
+
+        /// <summary>
+        /// <para>
+        /// Tests that the Each method returns Continue when performing a full scan without interruption.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// <para>The link address type.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="links">
+        /// <para>The links.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void TestFullScanReturnsContinue<T>(this ILinks<T> links) where T : IUnsignedNumber<T>, IComparisonOperators<T, T, bool>
+        {
+            var constants = links.Constants;
+            
+            // Create some test links
+            var link1 = links.Create();
+            var link2 = links.Create();
+            var link3 = links.CreateAndUpdate(link1, link2);
+            
+            // Test full scan returns Continue when not interrupted
+            var result = links.Each(foundLink => constants.Continue);
+            EnsureEqual(constants.Continue, result, "Full scan should return Continue when not interrupted by handler");
+            
+            // Test partial scan returns Break when interrupted 
+            var visitCount = T.Zero;
+            result = links.Each(foundLink =>
+            {
+                visitCount++;
+                return visitCount >= T.One ? constants.Break : constants.Continue;
+            });
+            EnsureEqual(constants.Break, result, "Scan should return Break when interrupted by handler");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixed the `Each` method in both `UnitedMemoryLinksBase.cs` and `SplitMemoryLinksBase.cs` to return the `Continue` constant when performing a full scan without interruption, as specified in issue #338.

## Changes Made

- **UnitedMemoryLinksBase.cs:354** - Changed `return @break;` to `return @continue;`
- **SplitMemoryLinksBase.cs:447** - Changed `return @break;` to `return @continue;`
- Added comprehensive regression tests for both implementations
- Tests verify that `Each` returns `Continue` when not interrupted by the handler
- Tests verify that `Each` returns `Break` when interrupted by the handler

## Test Plan

- [x] Added `FullScanReturnsContinueTest` to `GenericLinksTests.cs` for UnitedMemoryLinks
- [x] Added `FullScanReturnsContinueTest` to `SplitMemoryGenericLinksTests.cs` for SplitMemoryLinks  
- [x] Tests pass compilation and build successfully
- [x] All existing functionality is preserved

## Fixes

Fixes #338

🤖 Generated with [Claude Code](https://claude.ai/code)