### PR TITLE
Add benchmarks to compare nullable handler and non-nullable handler approaches #332

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/332
+Your prepared branch: issue-332-7a6ff77a
+Your prepared working directory: /tmp/gh-issue-solver-1757707700831
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/332
-Your prepared branch: issue-332-7a6ff77a
-Your prepared working directory: /tmp/gh-issue-solver-1757707700831
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Benchmarks/HandlerBenchmarks.cs
+++ b/csharp/Platform.Data.Doublets.Benchmarks/HandlerBenchmarks.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+using Platform.Delegates;
+using TLinkAddress = System.UInt64;
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace Platform.Data.Doublets.Benchmarks
+{
+    [SimpleJob]
+    [MemoryDiagnoser]
+    public class HandlerBenchmarks
+    {
+        private static ILinks<TLinkAddress> _links;
+        private static TLinkAddress _continueConstant;
+        private static TLinkAddress _breakConstant;
+        private static HeapResizableDirectMemory _dataMemory;
+        private static ReadHandler<TLinkAddress>? _nullHandler;
+        private static ReadHandler<TLinkAddress> _defaultHandler;
+        private static ReadHandler<TLinkAddress> _actualHandler;
+
+        [Params(10000, 100000)]
+        public static int N;
+
+        [GlobalSetup]
+        public static void Setup()
+        {
+            _dataMemory = new HeapResizableDirectMemory();
+            _links = new UnitedMemoryLinks<TLinkAddress>(_dataMemory).DecorateWithAutomaticUniquenessAndUsagesResolution();
+            _continueConstant = _links.Constants.Continue;
+            _breakConstant = _links.Constants.Break;
+            
+            // Setup handlers
+            _nullHandler = null;
+            _defaultHandler = default;
+            _actualHandler = (link) => _continueConstant; // Actual handler that just returns Continue
+            
+            // Create some test data
+            for (int i = 0; i < 1000; i++)
+            {
+                var link = _links.Create();
+                _links.Update(link, (TLinkAddress)(i % 10 + 1), (TLinkAddress)(i % 5 + 1));
+            }
+        }
+
+        [GlobalCleanup]
+        public static void Cleanup() 
+        {
+            _dataMemory.Dispose();
+        }
+
+        // Function that gets the handler and checks if it's null or default
+        private static TLinkAddress HandleNullableAndDefault(IList<TLinkAddress>? link, ReadHandler<TLinkAddress>? handler)
+        {
+            if (handler == null || handler == default)
+            {
+                return _continueConstant;
+            }
+            return handler(link);
+        }
+
+        // Function that gets the handler and checks if it's null
+        private static TLinkAddress HandleNullable(IList<TLinkAddress>? link, ReadHandler<TLinkAddress>? handler)
+        {
+            if (handler == null)
+            {
+                return _continueConstant;
+            }
+            return handler(link);
+        }
+
+        // Function that just calls the handler (non-nullable)
+        private static TLinkAddress HandleNonNullable(IList<TLinkAddress>? link, ReadHandler<TLinkAddress> handler)
+        {
+            if (handler == default)
+            {
+                return _continueConstant;
+            }
+            return handler(link);
+        }
+
+        [Benchmark]
+        public void NullableAndDefaultHandlerWithNull()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(link => HandleNullableAndDefault(link, _nullHandler), query);
+            }
+        }
+
+        [Benchmark]
+        public void NullableAndDefaultHandlerWithDefault()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(link => HandleNullableAndDefault(link, _defaultHandler), query);
+            }
+        }
+
+        [Benchmark]
+        public void NullableHandlerWithNull()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(link => HandleNullable(link, _nullHandler), query);
+            }
+        }
+
+        [Benchmark]
+        public void NullableHandlerWithDefault()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(link => HandleNullable(link, _defaultHandler), query);
+            }
+        }
+
+        [Benchmark]
+        public void NonNullableHandlerWithDefault()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(link => HandleNonNullable(link, _defaultHandler), query);
+            }
+        }
+
+        [Benchmark]
+        public void DirectHandlerCall()
+        {
+            var query = new Link<TLinkAddress>(_links.Constants.Any, _links.Constants.Any, _links.Constants.Any);
+            for (int i = 0; i < N; i++)
+            {
+                _links.Each(_actualHandler, query);
+            }
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Benchmarks/Program.cs
+++ b/csharp/Platform.Data.Doublets.Benchmarks/Program.cs
@@ -8,6 +8,7 @@ namespace Platform.Data.Doublets.Benchmarks
         {
             BenchmarkRunner.Run<CountBenchmarks>();
             BenchmarkRunner.Run<LinkStructBenchmarks>();
+            BenchmarkRunner.Run<HandlerBenchmarks>();
             // BenchmarkRunner.Run<MemoryBenchmarks>();
         }
     }


### PR DESCRIPTION
## Summary
Addresses issue #332 by implementing comprehensive benchmarks to compare the performance of different handler approaches:

- **Nullable and Default Handler Check**: Function that checks if handler is null or default, returns Continue constant if true, otherwise calls handler
- **Nullable Handler Check**: Function that checks if handler is null, returns Continue constant if true, otherwise calls handler  
- **Non-Nullable Handler Check**: Function that checks if handler is default, returns Continue constant if true, otherwise calls handler

## Implementation Details

### Created `HandlerBenchmarks.cs` with:
- **HandleNullableAndDefault**: Tests null OR default handler checking
- **HandleNullable**: Tests null handler checking only
- **HandleNonNullable**: Tests default handler checking (assumes non-nullable reference)
- **DirectHandlerCall**: Baseline performance test with direct handler invocation

### Benchmark Scenarios:
- `NullableAndDefaultHandlerWithNull`: Pass null handler to nullable+default checker
- `NullableAndDefaultHandlerWithDefault`: Pass default handler to nullable+default checker
- `NullableHandlerWithNull`: Pass null handler to nullable-only checker
- `NullableHandlerWithDefault`: Pass default handler to nullable-only checker
- `NonNullableHandlerWithDefault`: Pass default handler to non-nullable checker
- `DirectHandlerCall`: Direct handler invocation for performance baseline

### Test Configuration:
- Uses BenchmarkDotNet with `SimpleJob` and `MemoryDiagnoser`
- Tests with 10,000 and 100,000 iterations
- Creates test data with 1,000 links for realistic scenarios
- Updated `Program.cs` to include `HandlerBenchmarks` in benchmark runs

## Test plan
- [x] Build succeeds without errors
- [x] Benchmark application runs and validates correctly
- [x] All benchmark methods are properly configured with BenchmarkDotNet attributes
- [x] Memory usage diagnostics are enabled
- [x] Test scenarios cover the requirements from issue #332

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #332