### PR TITLE
Add extensions that return full Link instead of link address

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/310
+Your prepared branch: issue-310-5de3d1dc
+Your prepared working directory: /tmp/gh-issue-solver-1757712504916
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/310
-Your prepared branch: issue-310-5de3d1dc
-Your prepared working directory: /tmp/gh-issue-solver-1757712504916
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/LinkReturningExtensionsTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/LinkReturningExtensionsTests.cs
@@ -1,0 +1,127 @@
+using System;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+using Xunit;
+
+namespace Platform.Data.Doublets.Tests
+{
+    public static class LinkReturningExtensionsTests
+    {
+        [Fact]
+        public static void SearchOrDefaultAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var source = links.CreatePoint();
+            var target = links.CreatePoint();
+            var linkAddress = links.CreateAndUpdate(source, target);
+
+            // Test existing link
+            var foundLink = links.SearchOrDefaultAsLink(source, target);
+            Assert.False(foundLink.IsNull());
+            Assert.Equal(linkAddress, foundLink.Index);
+            Assert.Equal(source, foundLink.Source);
+            Assert.Equal(target, foundLink.Target);
+
+            // Test non-existing link
+            var anotherSource = links.CreatePoint();
+            var notFoundLink = links.SearchOrDefaultAsLink(anotherSource, target);
+            Assert.True(notFoundLink.IsNull());
+        }
+
+        [Fact]
+        public static void GetOrCreateAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var source = links.CreatePoint();
+            var target = links.CreatePoint();
+
+            // Test creation
+            var createdLink = links.GetOrCreateAsLink(source, target);
+            Assert.False(createdLink.IsNull());
+            Assert.Equal(source, createdLink.Source);
+            Assert.Equal(target, createdLink.Target);
+
+            // Test getting existing
+            var existingLink = links.GetOrCreateAsLink(source, target);
+            Assert.Equal(createdLink.Index, existingLink.Index);
+            Assert.Equal(createdLink.Source, existingLink.Source);
+            Assert.Equal(createdLink.Target, existingLink.Target);
+        }
+
+        [Fact]
+        public static void CreateAndUpdateAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var source = links.CreatePoint();
+            var target = links.CreatePoint();
+
+            var createdLink = links.CreateAndUpdateAsLink(source, target);
+            Assert.False(createdLink.IsNull());
+            Assert.Equal(source, createdLink.Source);
+            Assert.Equal(target, createdLink.Target);
+
+            // Verify link exists in storage
+            Assert.True(links.Exists(createdLink.Index));
+        }
+
+        [Fact]
+        public static void CreatePointAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var pointLink = links.CreatePointAsLink();
+            Assert.False(pointLink.IsNull());
+            Assert.Equal(pointLink.Index, pointLink.Source);
+            Assert.Equal(pointLink.Index, pointLink.Target);
+        }
+
+        [Fact]
+        public static void UpdateAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var originalSource = links.CreatePoint();
+            var originalTarget = links.CreatePoint();
+            var linkAddress = links.CreateAndUpdate(originalSource, originalTarget);
+
+            var newSource = links.CreatePoint();
+            var newTarget = links.CreatePoint();
+
+            var updatedLink = links.UpdateAsLink(linkAddress, newSource, newTarget);
+            Assert.False(updatedLink.IsNull());
+            Assert.Equal(linkAddress, updatedLink.Index);
+            Assert.Equal(newSource, updatedLink.Source);
+            Assert.Equal(newTarget, updatedLink.Target);
+        }
+
+        [Fact]
+        public static void FirstAsLinkTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            var firstPoint = links.CreatePoint();
+
+            var firstLink = links.FirstAsLink();
+            Assert.False(firstLink.IsNull());
+            Assert.Equal(firstPoint, firstLink.Index);
+        }
+
+        [Fact]
+        public static void FirstAsLinkThrowsOnEmptyStorageTest()
+        {
+            var mem = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(mem);
+
+            Assert.Throws<InvalidOperationException>(() => links.FirstAsLink());
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/ILinksExtensions.cs
@@ -1599,5 +1599,108 @@ namespace Platform.Data.Doublets
         }
 
         #endregion
+
+        #region Link-returning extensions
+
+        /// <summary>
+        /// Выполняет поиск связи с указанными Source (началом) и Target (концом) и возвращает полную структуру Link.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="source">Индекс связи, которая является началом для искомой связи.</param>
+        /// <param name="target">Индекс связи, которая является концом для искомой связи.</param>
+        /// <returns>Полная структура Link с указанными Source (началом) и Target (концом), или Link.Null если не найдена.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> SearchOrDefaultAsLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.SearchOrDefault(source, target);
+            if (EqualityComparer<TLinkAddress>.Default.Equals(address, default))
+            {
+                return Link<TLinkAddress>.Null;
+            }
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Создаёт связь (если она не существовала), либо возвращает полную структуру Link существующей связи с указанными Source (началом) и Target (концом).
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="source">Индекс связи, которая является началом на создаваемой связи.</param>
+        /// <param name="target">Индекс связи, которая является концом для создаваемой связи.</param>
+        /// <returns>Полная структура Link с указанным Source (началом) и Target (концом)</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> GetOrCreateAsLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.GetOrCreate(source, target);
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Создаёт новую связь и обновляет её содержимое, возвращая полную структуру Link.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="source">Индекс связи, которая является началом для создаваемой связи.</param>
+        /// <param name="target">Индекс связи, которая является концом для создаваемой связи.</param>
+        /// <returns>Полная структура Link созданной связи</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> CreateAndUpdateAsLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.CreateAndUpdate(source, target);
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Создаёт новую точку (связь, ссылающуюся саму на себя) и возвращает полную структуру Link.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <returns>Полная структура Link созданной точки</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> CreatePointAsLink<TLinkAddress>(this ILinks<TLinkAddress> links)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.CreatePoint();
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Обновляет связь с указанными началом (Source) и концом (Target) на связь с указанными началом (NewSource) и концом (NewTarget), возвращая полную структуру Link.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="link">Индекс обновляемой связи.</param>
+        /// <param name="newSource">Индекс связи, которая является началом связи, на которую выполняется обновление.</param>
+        /// <param name="newTarget">Индекс связи, которая является концом связи, на которую выполняется обновление.</param>
+        /// <returns>Полная структура Link обновлённой связи</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> UpdateAsLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress link, TLinkAddress newSource, TLinkAddress newTarget)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.Update(link, newSource, newTarget);
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Обновляет связь согласно ограничениям, возвращая полную структуру Link.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="restriction">Ограничения на содержимое связей.</param>
+        /// <returns>Полная структура Link обновлённой связи</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> UpdateAsLink<TLinkAddress>(this ILinks<TLinkAddress> links, IList<TLinkAddress>? restriction)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.Update(restriction);
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        /// <summary>
+        /// Возвращает полную структуру Link первой связи в хранилище.
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <returns>Полная структура Link первой связи</returns>
+        /// <exception cref="InvalidOperationException">В хранилище нет связей.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Link<TLinkAddress> FirstAsLink<TLinkAddress>(this ILinks<TLinkAddress> links)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var address = links.First();
+            return new Link<TLinkAddress>(links.GetLink(address));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary
- Added 7 new extension methods in `ILinksExtensions.cs` that return `Link<TLinkAddress>` instead of `TLinkAddress`
- Methods included: `SearchOrDefaultAsLink`, `GetOrCreateAsLink`, `CreateAndUpdateAsLink`, `CreatePointAsLink`, `UpdateAsLink` (two overloads), and `FirstAsLink`
- Added comprehensive unit tests in `LinkReturningExtensionsTests.cs`
- All methods follow existing code conventions and include Russian XML documentation

## Implementation Details
These extensions address issue #310 by providing alternatives to existing methods that return just the link address. Instead of returning `TLinkAddress`, these methods return the full `Link<TLinkAddress>` structure containing Index, Source, and Target properties.

The methods are named with the suffix `AsLink` to distinguish them from their address-returning counterparts and maintain backward compatibility.

## Test Plan
- [x] All new methods compile successfully
- [x] Unit tests pass for all new extension methods  
- [x] Manual testing with console application confirms correct functionality
- [x] No breaking changes to existing API
- [x] Methods handle edge cases (e.g., non-existent links return `Link.Null`)

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #310