### PR TITLE
Fix: Use correct setter method in tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/309
-Your prepared branch: issue-309-7c8629c7
-Your prepared working directory: /tmp/gh-issue-solver-1757713410660
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/309
+Your prepared branch: issue-309-7c8629c7
+Your prepared working directory: /tmp/gh-issue-solver-1757713410660
+
+Proceed.

--- a/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs
@@ -165,12 +165,12 @@ namespace Platform.Data.Doublets.Tests
 
             // Search for created link
             var setter1 = new Setter<T, T>(constants.Continue, constants.Break, constants.Null);
-            links.Each(setter1.SetFirstAndReturnFalse, constants.Any, h106E, h108E);
+            links.Each(setter1.SetFirstFromNonNullListAndReturnTrue, constants.Any, h106E, h108E);
             EnsureTrue(setter1.Result ==  linkAddress1);
 
             // Search for nonexistent link
             var setter2 = new Setter<T, T>(constants.Continue, constants.Break, constants.Null);
-            links.Each(setter2.SetFirstAndReturnFalse, constants.Any, h106E, h107E);
+            links.Each(setter2.SetFirstFromNonNullListAndReturnTrue, constants.Any, h106E, h107E);
             EnsureTrue(setter2.Result ==  constants.Null);
 
             // Update link to reference null (prepare for delete)


### PR DESCRIPTION
## Summary
- Fixed incorrect method calls in `TestRawNumbersCRUDOperations` method in `ILinksExtensions.cs`
- Replaced `SetFirstAndReturnFalse` with `SetFirstFromNonNullListAndReturnTrue` in two setter instances
- This brings consistency with all other setter usages throughout the test extension methods

## Changes Made
- Line 168: Fixed `setter1.SetFirstAndReturnFalse` → `setter1.SetFirstFromNonNullListAndReturnTrue` 
- Line 173: Fixed `setter2.SetFirstAndReturnFalse` → `setter2.SetFirstFromNonNullListAndReturnTrue`

## Test Plan
- [x] Build completed successfully without compilation errors
- [x] Verified all setter method calls in the file now use consistent naming
- [x] Changes maintain the same functionality while using the correct method signatures

Fixes #309

🤖 Generated with [Claude Code](https://claude.ai/code)