### PR TITLE
Add virtual DeleteAll method for overridable implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/287
-Your prepared branch: issue-287-43a044c6
-Your prepared working directory: /tmp/gh-issue-solver-1757717711835
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/287
+Your prepared branch: issue-287-43a044c6
+Your prepared working directory: /tmp/gh-issue-solver-1757717711835
+
+Proceed.

--- a/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs
+++ b/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs
@@ -186,4 +186,26 @@ public abstract class LinksDecoratorBase<TLinkAddress> : LinksOperatorBase<TLink
     {
         return _links.Delete(restriction: restriction, handler: handler);
     }
+
+    /// <summary>
+    ///     <para>
+    ///         Deletes all links. Can be overridden for more efficient implementations.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    public virtual void DeleteAll()
+    {
+        // Default implementation - same as the current extension method
+        var comparer = Comparer<TLinkAddress>.Default;
+        for (var i = Count(null); comparer.Compare(i, default) > 0; i = --i)
+        {
+            // Delete individual links using the base Delete method to avoid recursion
+            Delete(new List<TLinkAddress> { i }, null);
+            if (Count(null) != --i)
+            {
+                i = Count(null);
+            }
+        }
+    }
 }

--- a/csharp/Platform.Data.Doublets/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/ILinksExtensions.cs
@@ -154,6 +154,30 @@ namespace Platform.Data.Doublets
             return links.Delete(new LinkAddress<TLinkAddress>(linkToDelete), handler);
         }
 
+        /// <summary>
+        /// <para>
+        /// Deletes the links.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="TLinkAddress">
+        /// <para>The link.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="links">
+        /// <para>The links.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="linkToDelete">
+        /// <para>The link to delete.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TLinkAddress Delete<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress linkToDelete)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            return links.Delete(linkToDelete, null);
+        }
+
         /// <remarks>
         /// TODO: Возможно есть очень простой способ это сделать.
         /// (Например просто удалить файл, или изменить его размер таким образом,
@@ -163,13 +187,22 @@ namespace Platform.Data.Doublets
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DeleteAll<TLinkAddress>(this ILinks<TLinkAddress> links)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
         {
-            var comparer = Comparer<TLinkAddress>.Default;
-            for (var i = links.Count(); comparer.Compare(i, default) > 0; i = --i)
+            // Check if the implementation has overridden DeleteAll method
+            if (links is Decorators.LinksDecoratorBase<TLinkAddress> decorator)
             {
-                links.Delete(i);
-                if (links.Count() !=  --i)
+                decorator.DeleteAll();
+            }
+            else
+            {
+                // Default implementation
+                var comparer = Comparer<TLinkAddress>.Default;
+                for (var i = links.Count(); comparer.Compare(i, default) > 0; i = --i)
                 {
-                    i = links.Count();
+                    links.Delete(i);
+                    if (links.Count() !=  --i)
+                    {
+                        i = links.Count();
+                    }
                 }
             }
         }

--- a/examples/test_delete_all.cs
+++ b/examples/test_delete_all.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Data.Doublets.Decorators;
+using Platform.Memory;
+
+// Simple test to verify DeleteAll can be overridden
+public class TestMemoryLinks : LinksDecoratorBase<ulong>
+{
+    public bool CustomDeleteAllCalled { get; private set; } = false;
+    
+    public TestMemoryLinks(ILinks<ulong> links) : base(links) { }
+    
+    public override void DeleteAll()
+    {
+        CustomDeleteAllCalled = true;
+        Console.WriteLine("Custom DeleteAll implementation called!");
+        
+        // Call the default implementation for demonstration
+        base.DeleteAll();
+    }
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Testing DeleteAll override functionality...");
+        
+        // Create a basic memory links implementation
+        var memory = new HeapResizableDirectMemory();
+        var baseLinks = new UnitedMemoryLinks<ulong>(memory);
+        
+        // Wrap it with our test decorator
+        var testLinks = new TestMemoryLinks(baseLinks);
+        
+        // Create some test links
+        testLinks.Create(1, 2);
+        testLinks.Create(2, 3);
+        testLinks.Create(3, 4);
+        
+        Console.WriteLine($"Created {testLinks.Count(null)} links");
+        
+        // Call DeleteAll - should use our overridden method
+        testLinks.DeleteAll();
+        
+        Console.WriteLine($"After DeleteAll: {testLinks.Count(null)} links remain");
+        Console.WriteLine($"Custom implementation called: {testLinks.CustomDeleteAllCalled}");
+        
+        if (testLinks.CustomDeleteAllCalled)
+        {
+            Console.WriteLine("SUCCESS: DeleteAll can be overridden!");
+        }
+        else
+        {
+            Console.WriteLine("FAILURE: DeleteAll override was not called");
+        }
+    }
+}

--- a/examples/test_delete_all.csproj
+++ b/examples/test_delete_all.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
This PR implements a solution to make the `DeleteAll` extension method overridable by implementations, addressing issue #287.

### Changes Made
- **Added virtual `DeleteAll` method to `LinksDecoratorBase`**: Provides a default implementation that matches the current extension method behavior
- **Modified `DeleteAll` extension method**: Now checks if the links instance is a `LinksDecoratorBase` and calls its virtual method if available
- **Added `Delete` overload**: Added a convenience overload without the handler parameter for better compatibility
- **Included example test**: Demonstrates how to override the `DeleteAll` method in custom implementations

### How It Works
1. The extension method first checks if the `ILinks` instance is a `LinksDecoratorBase`
2. If it is, it calls the virtual `DeleteAll` method which can be overridden
3. If not, it falls back to the original implementation
4. Implementations can now override `DeleteAll` for more efficient bulk deletion (e.g., using `_header->AllocatedLinks` in `ResizableDirectMemoryLinks` as suggested in the TODO comment)

### Benefits
- **Backward compatibility**: Existing code continues to work unchanged
- **Extensibility**: Implementations can now provide optimized `DeleteAll` methods
- **Modern approach**: Follows the pattern suggested in the Rust example from the issue comments

### Example Usage
```csharp
public class EfficientMemoryLinks : LinksDecoratorBase<ulong>
{
    public override void DeleteAll()
    {
        // Custom efficient implementation
        // e.g., reset header->AllocatedLinks to 0
        Console.WriteLine("Using efficient DeleteAll implementation");
        base.DeleteAll(); // or custom logic
    }
}
```

Fixes #287

🤖 Generated with [Claude Code](https://claude.ai/code)