### PR TITLE
Rename address argument to path in UnitedMemoryLinks constructors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/245
-Your prepared branch: issue-245-55a50dd3
-Your prepared working directory: /tmp/gh-issue-solver-1757730427013
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/245
+Your prepared branch: issue-245-55a50dd3
+Your prepared working directory: /tmp/gh-issue-solver-1757730427013
+
+Proceed.

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs
@@ -29,20 +29,20 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// </para>
         /// <para></para>
         /// </summary>
-        /// <param name="address">
-        /// <para>A address.</para>
+        /// <param name="path">
+        /// <para>A path.</para>
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public UnitedMemoryLinks(string address) : this(address, DefaultLinksSizeStep) { }
+        public UnitedMemoryLinks(string path) : this(path, DefaultLinksSizeStep) { }
 
         /// <summary>
         /// Создаёт экземпляр базы данных Links в файле по указанному адресу, с указанным минимальным шагом расширения базы данных.
         /// </summary>
-        /// <param name="address">Полный пусть к файлу базы данных.</param>
+        /// <param name="path">Полный пусть к файлу базы данных.</param>
         /// <param name="memoryReservationStep">Минимальный шаг расширения базы данных в байтах.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public UnitedMemoryLinks(string address, long memoryReservationStep) : this(new FileMappedResizableDirectMemory(address, memoryReservationStep), memoryReservationStep) { }
+        public UnitedMemoryLinks(string path, long memoryReservationStep) : this(new FileMappedResizableDirectMemory(path, memoryReservationStep), memoryReservationStep) { }
 
         /// <summary>
         /// <para>


### PR DESCRIPTION
## Summary
- Renamed parameter from `address` to `path` in the string-based constructors of `UnitedMemoryLinks` class
- Updated XML documentation comments to reflect the parameter name change
- This improves code readability and semantic correctness as the parameter represents a file path

## Changes Made
- Modified `csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs`:
  - Constructor `UnitedMemoryLinks(string address)` → `UnitedMemoryLinks(string path)`
  - Constructor `UnitedMemoryLinks(string address, long memoryReservationStep)` → `UnitedMemoryLinks(string path, long memoryReservationStep)`
  - Updated corresponding XML documentation

## Test Plan
- [x] Code compiles successfully with no new errors
- [x] Existing tests pass (no compilation issues introduced)
- [x] No breaking changes as no existing code uses these string constructors

Fixes #245

🤖 Generated with [Claude Code](https://claude.ai/code)