### PR TITLE
Add ILinks container reference to Link struct for object-like interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/238
+Your prepared branch: issue-238-4d05c862
+Your prepared working directory: /tmp/gh-issue-solver-1757743091108
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/238
-Your prepared branch: issue-238-4d05c862
-Your prepared working directory: /tmp/gh-issue-solver-1757743091108
-
-Proceed.

--- a/csharp/Platform.Data.Doublets/Link.cs
+++ b/csharp/Platform.Data.Doublets/Link.cs
@@ -48,6 +48,14 @@ namespace Platform.Data.Doublets
         /// <para></para>
         /// </summary>
         public readonly TLinkAddress Target;
+        
+        /// <summary>
+        /// <para>
+        /// The links container storage reference for object-like interface operations.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        private readonly ILinks<TLinkAddress>? _links;
 
         /// <summary>
         /// <para>
@@ -60,7 +68,7 @@ namespace Platform.Data.Doublets
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Link(params TLinkAddress[] values)  { SetValues(values, out Index, out Source, out Target);}
+        public Link(params TLinkAddress[] values)  { SetValues(values, out Index, out Source, out Target); _links = null; }
 
         /// <summary>
         /// <para>
@@ -73,7 +81,7 @@ namespace Platform.Data.Doublets
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Link(IList<TLinkAddress>? values)  { SetValues(values, out Index, out Source, out Target);}
+        public Link(IList<TLinkAddress>? values)  { SetValues(values, out Index, out Source, out Target); _links = null; }
 
         /// <summary>
         /// <para>
@@ -95,10 +103,12 @@ namespace Platform.Data.Doublets
             if (other is Link<TLinkAddress> otherLink)
             {
                 SetValues(ref otherLink, out Index, out Source, out Target);
+                _links = otherLink._links;
             }
             else if(other is IList<TLinkAddress> otherList)
             {
                 SetValues(otherList, out Index, out Source, out Target);
+                _links = null;
             }
             else
             {
@@ -117,7 +127,7 @@ namespace Platform.Data.Doublets
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Link(ref Link<TLinkAddress> other)  { SetValues(ref other, out Index, out Source, out Target);}
+        public Link(ref Link<TLinkAddress> other)  { SetValues(ref other, out Index, out Source, out Target); _links = other._links; }
 
         /// <summary>
         /// <para>
@@ -143,6 +153,59 @@ namespace Platform.Data.Doublets
             Index = index;
             Source = source;
             Target = target;
+            _links = null;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new <see cref="Link"/> instance with a reference to the links container.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="links">
+        /// <para>The links container storage.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="index">
+        /// <para>A index.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="source">
+        /// <para>A source.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="target">
+        /// <para>A target.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Link(ILinks<TLinkAddress> links, TLinkAddress index, TLinkAddress source, TLinkAddress target)
+        {
+            _links = links;
+            Index = index;
+            Source = source;
+            Target = target;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new <see cref="Link"/> instance with a reference to the links container using link data.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="links">
+        /// <para>The links container storage.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="linkData">
+        /// <para>The link data.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Link(ILinks<TLinkAddress> links, IList<TLinkAddress>? linkData)
+        {
+            _links = links;
+            SetValues(linkData, out Index, out Source, out Target);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SetValues(ref Link<TLinkAddress> other, out TLinkAddress index, out TLinkAddress source, out TLinkAddress target)
@@ -314,6 +377,147 @@ namespace Platform.Data.Doublets
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override string ToString()  { return Index ==  _constants.Null ? ToString(Source, Target) : ToString(Index, Source, Target);}
+
+        #region Object-like Interface
+
+        /// <summary>
+        /// <para>
+        /// Gets the links container storage reference.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        public ILinks<TLinkAddress>? Links
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _links;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Updates this link's source and target using the links container.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="newSource">
+        /// <para>The new source.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="newTarget">
+        /// <para>The new target.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The updated link address.</para>
+        /// <para></para>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// <para>Thrown when links container is not available.</para>
+        /// <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TLinkAddress Update(TLinkAddress newSource, TLinkAddress newTarget)
+        {
+            if (_links == null)
+            {
+                throw new InvalidOperationException("Links container is not available for this link instance.");
+            }
+            return _links.Update(Index, newSource, newTarget);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Updates this link using the links container.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="substitution">
+        /// <para>The substitution values.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The updated link address.</para>
+        /// <para></para>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// <para>Thrown when links container is not available.</para>
+        /// <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TLinkAddress Update(IList<TLinkAddress>? substitution)
+        {
+            if (_links == null)
+            {
+                throw new InvalidOperationException("Links container is not available for this link instance.");
+            }
+            return _links.Update(new TLinkAddress[] { Index }, substitution);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Deletes this link using the links container.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <returns>
+        /// <para>The deleted link address.</para>
+        /// <para></para>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// <para>Thrown when links container is not available.</para>
+        /// <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TLinkAddress Delete()
+        {
+            if (_links == null)
+            {
+                throw new InvalidOperationException("Links container is not available for this link instance.");
+            }
+            return _links.Delete(Index);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Gets a refreshed version of this link from the links container.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <returns>
+        /// <para>The refreshed link.</para>
+        /// <para></para>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// <para>Thrown when links container is not available.</para>
+        /// <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Link<TLinkAddress> Refresh()
+        {
+            if (_links == null)
+            {
+                throw new InvalidOperationException("Links container is not available for this link instance.");
+            }
+            var linkData = _links.GetLink(Index);
+            return new Link<TLinkAddress>(_links, linkData);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Determines whether the links container is available for object-like operations.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <returns>
+        /// <para>True if links container is available, false otherwise.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool HasLinksContainer()
+        {
+            return _links != null;
+        }
+
+        #endregion
 
         #region IList
 

--- a/examples/LinkObjectInterfaceTest.cs
+++ b/examples/LinkObjectInterfaceTest.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+
+namespace Platform.Data.Doublets.Examples
+{
+    /// <summary>
+    /// <para>
+    /// Example demonstrating the object-like interface for Link struct.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    public class Program
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Testing Link struct object-like interface...");
+            
+            // Create a memory-based links storage
+            var memory = new HeapResizableDirectMemory();
+            var memoryManager = new UnitedMemoryLinks<ulong>(memory);
+            
+            // Test 1: Create a link with traditional approach
+            Console.WriteLine("\n1. Traditional approach:");
+            var linkAddress = memoryManager.Create();
+            var traditionalLink = new Link<ulong>(memoryManager.GetLink(linkAddress));
+            Console.WriteLine($"Created link: {traditionalLink}");
+            Console.WriteLine($"Has links container: {traditionalLink.HasLinksContainer()}");
+            
+            // Test 2: Create a link with object-like interface
+            Console.WriteLine("\n2. Object-like interface approach:");
+            var objectLink = new Link<ulong>(memoryManager, linkAddress, linkAddress, linkAddress);
+            Console.WriteLine($"Created object link: {objectLink}");
+            Console.WriteLine($"Has links container: {objectLink.HasLinksContainer()}");
+            Console.WriteLine($"Links container available: {objectLink.Links != null}");
+            
+            // Test 3: Update using object-like interface
+            Console.WriteLine("\n3. Update using object-like interface:");
+            var linkAddress2 = memoryManager.Create();
+            var linkAddress3 = memoryManager.Create();
+            
+            var updatedAddress = objectLink.Update(linkAddress2, linkAddress3);
+            Console.WriteLine($"Updated link address: {updatedAddress}");
+            
+            // Refresh to get updated values
+            var refreshedLink = objectLink.Refresh();
+            Console.WriteLine($"Refreshed link: {refreshedLink}");
+            
+            // Test 4: Test with link created from links container and link data
+            Console.WriteLine("\n4. Create link using container and link data:");
+            var linkData = new List<ulong> { linkAddress3, linkAddress2, linkAddress };
+            var dataLink = new Link<ulong>(memoryManager, linkData);
+            Console.WriteLine($"Data link: {dataLink}");
+            Console.WriteLine($"Has links container: {dataLink.HasLinksContainer()}");
+            
+            // Test 5: Test error handling when no links container is available
+            Console.WriteLine("\n5. Error handling test:");
+            var standaloneLink = new Link<ulong>(1, 2, 3);
+            Console.WriteLine($"Standalone link: {standaloneLink}");
+            Console.WriteLine($"Has links container: {standaloneLink.HasLinksContainer()}");
+            
+            try
+            {
+                standaloneLink.Update(4, 5);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.WriteLine($"Expected error: {ex.Message}");
+            }
+            
+            Console.WriteLine("\nAll tests completed successfully!");
+            
+            // Cleanup
+            memoryManager.Dispose();
+        }
+    }
+}

--- a/examples/TestProject.csproj
+++ b/examples/TestProject.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

This PR implements the requested feature from issue #238, adding an `ILinks<TLinkAddress>` container storage reference to the `Link` struct to enable object-like interface operations.

### Key Changes

- **Added ILinks container reference**: New private readonly field `_links` in Link struct
- **Enhanced constructors**: Updated existing constructors and added new ones that accept ILinks parameter
- **Object-like interface methods**:
  - `Update(newSource, newTarget)` - Direct link updates using container
  - `Update(substitution)` - Updates with substitution values
  - `Delete()` - Direct link deletion
  - `Refresh()` - Get updated link data from container
  - `HasLinksContainer()` - Check if container is available
- **Links property**: Access to the container reference
- **Comprehensive error handling**: Clear exceptions when container is not available
- **Example code**: Demonstrates the new object-like interface usage

### Usage Examples

**Traditional approach:**
```csharp
var link = new Link<ulong>(links.GetLink(linkAddress));
// Operations require links container reference
links.Update(linkAddress, newSource, newTarget);
links.Delete(linkAddress);
```

**New object-like interface:**
```csharp
var link = new Link<ulong>(links, linkAddress, source, target);
// Direct operations on the link object
link.Update(newSource, newTarget);
link.Delete();
var refreshed = link.Refresh();
```

### Backward Compatibility

All existing Link struct usage continues to work unchanged. The new functionality is opt-in through new constructors that accept the ILinks parameter.

### Test Results

✅ Build succeeds without errors  
✅ All existing functionality preserved  
✅ New object-like interface tested and working  
✅ Proper error handling verified  

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #238