### PR TITLE
Implement byte[] to sequence and back converters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/207
+Your prepared branch: issue-207-68d68fb5
+Your prepared working directory: /tmp/gh-issue-solver-1757769604286
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/207
-Your prepared branch: issue-207-68d68fb5
-Your prepared working directory: /tmp/gh-issue-solver-1757769604286
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/Converters/ByteArrayConvertersTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/Converters/ByteArrayConvertersTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Platform.Data.Doublets.Converters;
+using Platform.Data.Doublets.Decorators;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+using Xunit;
+
+namespace Platform.Data.Doublets.Tests.Converters
+{
+    public static class ByteArrayConvertersTests
+    {
+        [Fact]
+        public static void ByteArrayToSequenceAndBackTest()
+        {
+            Using<uint>(links => TestByteArrayConversions(links));
+            Using<ulong>(links => TestByteArrayConversions(links));
+        }
+
+        [Fact]
+        public static void EmptyByteArrayTest()
+        {
+            Using<uint>(links => TestEmptyByteArray(links));
+            Using<ulong>(links => TestEmptyByteArray(links));
+        }
+
+        [Fact]
+        public static void SingleByteTest()
+        {
+            Using<uint>(links => TestSingleByte(links));
+            Using<ulong>(links => TestSingleByte(links));
+        }
+
+        [Fact]
+        public static void MultipleByteArraysTest()
+        {
+            Using<uint>(links => TestMultipleByteArrays(links));
+            Using<ulong>(links => TestMultipleByteArrays(links));
+        }
+
+        [Fact]
+        public static void ExtensionMethodsTest()
+        {
+            Using<uint>(links => TestExtensionMethods(links));
+            Using<ulong>(links => TestExtensionMethods(links));
+        }
+
+        private static void TestByteArrayConversions<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var toSequenceConverter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            var toByteArrayConverter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+
+            // Test various byte arrays
+            var testArrays = new byte[][]
+            {
+                new byte[] { 0x01, 0x02, 0x03 },
+                new byte[] { 0xFF, 0x00, 0x80, 0x7F },
+                new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F }, // "Hello" in ASCII
+                new byte[] { 0x00 },
+                new byte[] { 0xFF },
+                new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }
+            };
+
+            foreach (var original in testArrays)
+            {
+                var sequence = toSequenceConverter.Convert(original);
+                Assert.NotEqual(links.Constants.Null, sequence);
+                Assert.True(links.Exists(sequence));
+
+                var converted = toByteArrayConverter.Convert(sequence);
+                Assert.Equal(original.Length, converted.Length);
+                
+                for (int i = 0; i < original.Length; i++)
+                {
+                    Assert.Equal(original[i], converted[i]);
+                }
+            }
+        }
+
+        private static void TestEmptyByteArray<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var toSequenceConverter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            var toByteArrayConverter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+
+            var emptyArray = Array.Empty<byte>();
+            var sequence = toSequenceConverter.Convert(emptyArray);
+            
+            Assert.Equal(links.Constants.Null, sequence);
+
+            var converted = toByteArrayConverter.Convert(sequence);
+            Assert.Empty(converted);
+        }
+
+        private static void TestSingleByte<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var toSequenceConverter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            var toByteArrayConverter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+
+            var singleByteArray = new byte[] { 0x42 };
+            var sequence = toSequenceConverter.Convert(singleByteArray);
+            
+            Assert.NotEqual(links.Constants.Null, sequence);
+            Assert.True(links.Exists(sequence));
+
+            var converted = toByteArrayConverter.Convert(sequence);
+            Assert.Single(converted);
+            Assert.Equal(0x42, converted[0]);
+        }
+
+        private static void TestMultipleByteArrays<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var toSequenceConverter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            var toByteArrayConverter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+
+            var array1 = new byte[] { 0x01, 0x02 };
+            var array2 = new byte[] { 0x03, 0x04 };
+            var array3 = new byte[] { 0x01, 0x02 }; // Same as array1
+
+            var sequence1 = toSequenceConverter.Convert(array1);
+            var sequence2 = toSequenceConverter.Convert(array2);
+            var sequence3 = toSequenceConverter.Convert(array3);
+
+            // Different arrays should create different sequences
+            Assert.NotEqual(sequence1, sequence2);
+            
+            // Same arrays should create the same sequence (due to GetOrCreate)
+            Assert.Equal(sequence1, sequence3);
+
+            // Verify conversions back
+            var converted1 = toByteArrayConverter.Convert(sequence1);
+            var converted2 = toByteArrayConverter.Convert(sequence2);
+
+            Assert.Equal(array1, converted1);
+            Assert.Equal(array2, converted2);
+        }
+
+        private static void TestExtensionMethods<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var originalArray = new byte[] { 0x10, 0x20, 0x30, 0x40 };
+            
+            var sequence = links.CreateSequenceFromByteArray(originalArray);
+            Assert.NotEqual(links.Constants.Null, sequence);
+            Assert.True(links.Exists(sequence));
+
+            var convertedArray = links.ConvertSequenceToByteArray(sequence);
+            Assert.Equal(originalArray, convertedArray);
+        }
+
+        [Fact]
+        public static void NullArgumentsTest()
+        {
+            Using<uint>(links => TestNullArguments(links));
+        }
+
+        private static void TestNullArguments<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            // Test constructor with null links
+            Assert.Throws<ArgumentNullException>(() => new ByteArrayToSequenceConverter<TLinkAddress>(null));
+            Assert.Throws<ArgumentNullException>(() => new SequenceToByteArrayConverter<TLinkAddress>(null));
+
+            // Test Convert method with null array
+            var toSequenceConverter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            Assert.Throws<ArgumentNullException>(() => toSequenceConverter.Convert(null));
+        }
+
+        [Fact]
+        public static void NonExistentSequenceTest()
+        {
+            Using<uint>(links => TestNonExistentSequence(links));
+        }
+
+        private static void TestNonExistentSequence<TLinkAddress>(ILinks<TLinkAddress> links)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var toByteArrayConverter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+            
+            // Create a non-existent link address
+            var nonExistentAddress = TLinkAddress.CreateTruncating(999999);
+            
+            Assert.Throws<ArgumentException>(() => toByteArrayConverter.Convert(nonExistentAddress));
+        }
+
+        private static void Using<TLinkAddress>(Action<ILinks<TLinkAddress>> action) 
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>, IShiftOperators<TLinkAddress, int, TLinkAddress>, 
+                IBitwiseOperators<TLinkAddress, TLinkAddress, TLinkAddress>, IMinMaxValue<TLinkAddress>, 
+                IComparisonOperators<TLinkAddress, TLinkAddress, bool>
+        {
+            var unitedMemoryLinks = new UnitedMemoryLinks<TLinkAddress>(new HeapResizableDirectMemory());
+            using (var logFile = File.Open($"byteArrayConvertersTest_{typeof(TLinkAddress).Name}.txt", FileMode.Create, FileAccess.Write))
+            {
+                var decoratedStorage = new LoggingDecorator<TLinkAddress>(unitedMemoryLinks, logFile);
+                action(decoratedStorage);
+            }
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/Converters/ByteArrayToSequenceConverter.cs
+++ b/csharp/Platform.Data.Doublets/Converters/ByteArrayToSequenceConverter.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Platform.Converters;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Platform.Data.Doublets.Converters
+{
+    /// <summary>
+    /// <para>
+    /// Represents a converter that converts byte arrays to doublet sequences.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    /// <typeparam name="TLinkAddress">
+    /// <para>The type of link address.</para>
+    /// <para></para>
+    /// </typeparam>
+    public class ByteArrayToSequenceConverter<TLinkAddress> : IConverter<byte[], TLinkAddress>
+        where TLinkAddress : IUnsignedNumber<TLinkAddress>
+    {
+        private readonly ILinks<TLinkAddress> _links;
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new instance of the <see cref="ByteArrayToSequenceConverter{TLinkAddress}"/> class.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="links">
+        /// <para>The links storage to use for creating sequences.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ByteArrayToSequenceConverter(ILinks<TLinkAddress> links)
+        {
+            _links = links ?? throw new ArgumentNullException(nameof(links));
+        }
+
+        /// <summary>
+        /// <para>
+        /// Converts a byte array to a doublet sequence.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="source">
+        /// <para>The byte array to convert.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The link address of the created sequence.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TLinkAddress Convert(byte[] source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (source.Length == 0)
+            {
+                return _links.Constants.Null;
+            }
+
+            if (source.Length == 1)
+            {
+                // For single byte, create a point link with the byte value
+                var byteValue = TLinkAddress.CreateTruncating(source[0]);
+                return _links.GetOrCreate(byteValue, byteValue);
+            }
+
+            // For multiple bytes, create a chain of links representing the sequence
+            var firstByteValue = TLinkAddress.CreateTruncating(source[0]);
+            var firstByteLink = _links.GetOrCreate(firstByteValue, firstByteValue);
+            
+            var currentSequence = firstByteLink;
+            
+            for (int i = 1; i < source.Length; i++)
+            {
+                var byteValue = TLinkAddress.CreateTruncating(source[i]);
+                var byteLink = _links.GetOrCreate(byteValue, byteValue);
+                
+                // Create a new link that connects the current sequence with the next byte
+                currentSequence = _links.GetOrCreate(currentSequence, byteLink);
+            }
+            
+            return currentSequence;
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/Converters/ILinksConverterExtensions.cs
+++ b/csharp/Platform.Data.Doublets/Converters/ILinksConverterExtensions.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Platform.Data.Doublets.Converters
+{
+    /// <summary>
+    /// <para>
+    /// Provides extension methods for ILinks to work with byte array converters.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    public static class ILinksConverterExtensions
+    {
+        /// <summary>
+        /// <para>
+        /// Converts a byte array to a doublet sequence.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="TLinkAddress">
+        /// <para>The type of link address.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="links">
+        /// <para>The links storage.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="bytes">
+        /// <para>The byte array to convert.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The link address of the created sequence.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TLinkAddress CreateSequenceFromByteArray<TLinkAddress>(this ILinks<TLinkAddress> links, byte[] bytes)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var converter = new ByteArrayToSequenceConverter<TLinkAddress>(links);
+            return converter.Convert(bytes);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Converts a doublet sequence back to a byte array.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <typeparam name="TLinkAddress">
+        /// <para>The type of link address.</para>
+        /// <para></para>
+        /// </typeparam>
+        /// <param name="links">
+        /// <para>The links storage.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="sequence">
+        /// <para>The link address of the sequence to convert.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The reconstructed byte array.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] ConvertSequenceToByteArray<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress sequence)
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            var converter = new SequenceToByteArrayConverter<TLinkAddress>(links);
+            return converter.Convert(sequence);
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/Converters/SequenceToByteArrayConverter.cs
+++ b/csharp/Platform.Data.Doublets/Converters/SequenceToByteArrayConverter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Platform.Converters;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Platform.Data.Doublets.Converters
+{
+    /// <summary>
+    /// <para>
+    /// Represents a converter that converts doublet sequences back to byte arrays.
+    /// </para>
+    /// <para></para>
+    /// </summary>
+    /// <typeparam name="TLinkAddress">
+    /// <para>The type of link address.</para>
+    /// <para></para>
+    /// </typeparam>
+    public class SequenceToByteArrayConverter<TLinkAddress> : IConverter<TLinkAddress, byte[]>
+        where TLinkAddress : IUnsignedNumber<TLinkAddress>
+    {
+        private readonly ILinks<TLinkAddress> _links;
+
+        /// <summary>
+        /// <para>
+        /// Initializes a new instance of the <see cref="SequenceToByteArrayConverter{TLinkAddress}"/> class.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="links">
+        /// <para>The links storage to use for reading sequences.</para>
+        /// <para></para>
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SequenceToByteArrayConverter(ILinks<TLinkAddress> links)
+        {
+            _links = links ?? throw new ArgumentNullException(nameof(links));
+        }
+
+        /// <summary>
+        /// <para>
+        /// Converts a doublet sequence back to a byte array.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="sequence">
+        /// <para>The link address of the sequence to convert.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The reconstructed byte array.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte[] Convert(TLinkAddress sequence)
+        {
+            if (EqualityComparer<TLinkAddress>.Default.Equals(sequence, _links.Constants.Null))
+            {
+                return Array.Empty<byte>();
+            }
+
+            if (!_links.Exists(sequence))
+            {
+                throw new ArgumentException($"Sequence with address {sequence} does not exist.", nameof(sequence));
+            }
+
+            var bytes = new List<byte>();
+            var visited = new HashSet<TLinkAddress>();
+            
+            WalkSequence(sequence, bytes, visited);
+            
+            return bytes.ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WalkSequence(TLinkAddress current, List<byte> bytes, HashSet<TLinkAddress> visited)
+        {
+            if (EqualityComparer<TLinkAddress>.Default.Equals(current, _links.Constants.Null) || 
+                !_links.Exists(current) ||
+                !visited.Add(current))
+            {
+                return;
+            }
+
+            var link = _links.GetLink(current);
+            var source = _links.GetSource(link);
+            var target = _links.GetTarget(link);
+
+            // If source and target are the same (point link), it represents a single byte value
+            if (EqualityComparer<TLinkAddress>.Default.Equals(source, target))
+            {
+                var byteValue = ulong.CreateTruncating(source);
+                if (byteValue <= byte.MaxValue)
+                {
+                    bytes.Add((byte)byteValue);
+                }
+                return;
+            }
+
+            // First, recursively walk the source (which contains the previous sequence or byte)
+            WalkSequence(source, bytes, visited);
+
+            // Then, handle the target
+            if (_links.Exists(target))
+            {
+                var targetLink = _links.GetLink(target);
+                var targetSource = _links.GetSource(targetLink);
+                var targetTarget = _links.GetTarget(targetLink);
+                
+                if (EqualityComparer<TLinkAddress>.Default.Equals(targetSource, targetTarget))
+                {
+                    // Target is a point link representing a byte value
+                    var byteValue = ulong.CreateTruncating(targetSource);
+                    if (byteValue <= byte.MaxValue)
+                    {
+                        bytes.Add((byte)byteValue);
+                    }
+                }
+                else
+                {
+                    // Target is a sequence, recursively walk it
+                    WalkSequence(target, bytes, visited);
+                }
+            }
+            else
+            {
+                // Target is a direct byte value
+                var byteValue = ulong.CreateTruncating(target);
+                if (byteValue <= byte.MaxValue)
+                {
+                    bytes.Add((byte)byteValue);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements `ByteArrayToSequenceConverter<TLinkAddress>` for converting byte arrays to doublet sequences
- Implements `SequenceToByteArrayConverter<TLinkAddress>` for reconstructing byte arrays from doublet sequences  
- Adds `ILinksConverterExtensions` with convenient extension methods
- Provides comprehensive unit tests covering various scenarios

## Implementation Details
The converters create chain-like sequences where:
- Single bytes are represented as point links (source == target == byte value)
- Multi-byte arrays are represented as chains where each link connects the previous sequence/byte with the next byte
- Round-trip conversion preserves original byte array content exactly

## Test Coverage
- Basic conversion round-trips for various byte arrays
- Empty byte array handling
- Single byte conversion
- Multiple byte arrays with different content
- Extension method functionality
- Error handling for null arguments and non-existent sequences

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #207