### PR TITLE
Add 3-tuple conversion support to Link struct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/205
-Your prepared branch: issue-205-6c1a8373
-Your prepared working directory: /tmp/gh-issue-solver-1757770735186
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/205
+Your prepared branch: issue-205-6c1a8373
+Your prepared working directory: /tmp/gh-issue-solver-1757770735186
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/LinkTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/LinkTests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+
+namespace Platform.Data.Doublets.Tests
+{
+    public static class LinkTests
+    {
+        [Fact]
+        public static void ImplicitConversionToTupleTest()
+        {
+            var link = new Link<ulong>(1, 2, 3);
+            
+            (ulong, ulong, ulong) tuple = link;
+            
+            Assert.Equal(1UL, tuple.Item1);
+            Assert.Equal(2UL, tuple.Item2);
+            Assert.Equal(3UL, tuple.Item3);
+        }
+
+        [Fact]
+        public static void ImplicitConversionFromTupleTest()
+        {
+            var tuple = (1UL, 2UL, 3UL);
+            
+            Link<ulong> link = tuple;
+            
+            Assert.Equal(1UL, link.Index);
+            Assert.Equal(2UL, link.Source);
+            Assert.Equal(3UL, link.Target);
+        }
+
+        [Fact]
+        public static void TupleRoundTripConversionTest()
+        {
+            var originalLink = new Link<ulong>(10, 20, 30);
+            
+            (ulong, ulong, ulong) tuple = originalLink;
+            Link<ulong> convertedBackLink = tuple;
+            
+            Assert.Equal(originalLink.Index, convertedBackLink.Index);
+            Assert.Equal(originalLink.Source, convertedBackLink.Source);
+            Assert.Equal(originalLink.Target, convertedBackLink.Target);
+            Assert.Equal(originalLink, convertedBackLink);
+        }
+
+        [Fact]
+        public static void TupleConversionWithDifferentNumericTypesTest()
+        {
+            var intLink = new Link<uint>(1, 2, 3);
+            
+            (uint, uint, uint) intTuple = intLink;
+            
+            Assert.Equal(1U, intTuple.Item1);
+            Assert.Equal(2U, intTuple.Item2);
+            Assert.Equal(3U, intTuple.Item3);
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/Link.cs
+++ b/csharp/Platform.Data.Doublets/Link.cs
@@ -302,6 +302,12 @@ namespace Platform.Data.Doublets
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Link<TLinkAddress>(TLinkAddress[] linkArray)  { return new Link<TLinkAddress>(linkArray);}
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator (TLinkAddress, TLinkAddress, TLinkAddress)(Link<TLinkAddress> link)  { return (link.Index, link.Source, link.Target);}
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Link<TLinkAddress>((TLinkAddress, TLinkAddress, TLinkAddress) tuple)  { return new Link<TLinkAddress>(tuple.Item1, tuple.Item2, tuple.Item3);}
+
         /// <summary>
         /// <para>
         /// Returns the string.


### PR DESCRIPTION
## Summary
- Implements implicit conversion operators to convert `Link<TLinkAddress>` to and from `ValueTuple<TLinkAddress, TLinkAddress, TLinkAddress>`
- Enables seamless conversion between Link objects and 3-tuples (Index, Source, Target)
- Adds comprehensive unit tests covering both conversion directions and round-trip scenarios

## Changes
- Added implicit operator from `Link<TLinkAddress>` to `(TLinkAddress, TLinkAddress, TLinkAddress)`
- Added implicit operator from `(TLinkAddress, TLinkAddress, TLinkAddress)` to `Link<TLinkAddress>`
- Created `LinkTests.cs` with comprehensive test coverage for tuple conversions

## Test plan
- [x] Verify implicit conversion from Link to tuple works correctly
- [x] Verify implicit conversion from tuple to Link works correctly
- [x] Verify round-trip conversion preserves data integrity
- [x] Verify functionality works with different numeric types (uint, ulong)
- [x] All tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #205