### PR TITLE
Add GetOrCreateLink extension method that returns not an address but all link's contents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/195
+Your prepared branch: issue-195-87e1a7d9
+Your prepared working directory: /tmp/gh-issue-solver-1757775045376
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/195
-Your prepared branch: issue-195-87e1a7d9
-Your prepared working directory: /tmp/gh-issue-solver-1757775045376
-
-Proceed.

--- a/csharp/Platform.Data.Doublets/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/ILinksExtensions.cs
@@ -971,6 +971,19 @@ namespace Platform.Data.Doublets
             return link;
         }
 
+        /// <summary>
+        /// Создаёт связь (если она не существовала), либо возвращает содержимое существующей связи с указанными Source (началом) и Target (концом).
+        /// </summary>
+        /// <param name="links">Хранилище связей.</param>
+        /// <param name="source">Индекс связи, которая является началом на создаваемой связи.</param>
+        /// <param name="target">Индекс связи, которая является концом для создаваемой связи.</param>
+        /// <returns>Содержимое связи, с указанным Source (началом) и Target (концом)</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IList<TLinkAddress>? GetOrCreateLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
+        {
+            return links.GetLink(links.GetOrCreate(source, target));
+        }
+
         public static TLinkAddress UpdateOrCreateOrGet<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target, TLinkAddress newSource, TLinkAddress newTarget)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
         {
             var constants = links.Constants;


### PR DESCRIPTION
## Summary

This PR implements a new `GetOrCreateLink` extension method as requested in issue #195. The method combines the common pattern `links.GetLink(links.GetOrCreate(...))` into a single convenient call.

## Changes

- Added `GetOrCreateLink<TLinkAddress>` extension method to `ILinksExtensions.cs`
- The method takes `source` and `target` parameters and returns `IList<TLinkAddress>?` containing the full link contents
- Includes proper XML documentation in Russian to match the existing codebase style
- Method is marked with `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for performance

## Implementation Details

```csharp
public static IList<TLinkAddress>? GetOrCreateLink<TLinkAddress>(this ILinks<TLinkAddress> links, TLinkAddress source, TLinkAddress target)  
    where TLinkAddress : IUnsignedNumber<TLinkAddress>
{
    return links.GetLink(links.GetOrCreate(source, target));
}
```

## Usage Example

Before:
```csharp
var linkContents = links.GetLink(links.GetOrCreate(source, target));
```

After:
```csharp
var linkContents = links.GetOrCreateLink(source, target);
```

## Testing

- Successfully builds with no compilation errors
- All existing unit tests pass
- Implementation follows existing code patterns and conventions

Fixes #195

🤖 Generated with [Claude Code](https://claude.ai/code)