### PR TITLE
Add test that creates sequence full of single character/element using different deduplication methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/191
+Your prepared branch: issue-191-d711698e
+Your prepared working directory: /tmp/gh-issue-solver-1757777904820
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/191
-Your prepared branch: issue-191-d711698e
-Your prepared working directory: /tmp/gh-issue-solver-1757777904820
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/GenericLinksTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/GenericLinksTests.cs
@@ -38,6 +38,91 @@ namespace Platform.Data.Doublets.Tests
             Using<uint>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
             Using<ulong>(links => links.DecorateWithAutomaticUniquenessAndUsagesResolution().TestMultipleRandomCreationsAndDeletions(100));
         }
+
+        [Fact]
+        public static void SingleCharacterSequenceWithDeduplicationTest()
+        {
+            Using<byte>(links => TestSingleCharacterSequenceWithDeduplication(links));
+            Using<ushort>(links => TestSingleCharacterSequenceWithDeduplication(links));
+            Using<uint>(links => TestSingleCharacterSequenceWithDeduplication(links));
+            Using<ulong>(links => TestSingleCharacterSequenceWithDeduplication(links));
+        }
+
+        private static void TestSingleCharacterSequenceWithDeduplication<TLinkAddress>(ILinks<TLinkAddress> links) 
+            where TLinkAddress : IUnsignedNumber<TLinkAddress>, IShiftOperators<TLinkAddress,int,TLinkAddress>, IBitwiseOperators<TLinkAddress,TLinkAddress,TLinkAddress>, IMinMaxValue<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
+        {
+            // Create a single character/element that will be used to build sequences
+            var character = links.CreatePoint();
+
+            // Test 1: Create sequences without deduplication - each link should be unique even if content is the same
+            var sequenceWithoutDedup1 = links.CreateAndUpdate(character, character);
+            var sequenceWithoutDedup2 = links.CreateAndUpdate(character, character);
+            var sequenceWithoutDedup3 = links.CreateAndUpdate(character, character);
+
+            // All three should be different link addresses despite having same content (without deduplication active)
+            Assert.NotEqual(sequenceWithoutDedup1, sequenceWithoutDedup2);
+            Assert.NotEqual(sequenceWithoutDedup2, sequenceWithoutDedup3);
+            Assert.NotEqual(sequenceWithoutDedup1, sequenceWithoutDedup3);
+
+            // Test 2: Test deduplication using GetOrCreate method which checks for existing links
+            var sequenceGetOrCreate1 = links.GetOrCreate(character, character);
+            var sequenceGetOrCreate2 = links.GetOrCreate(character, character);
+
+            // GetOrCreate should return the same address for identical content
+            Assert.Equal(sequenceGetOrCreate1, sequenceGetOrCreate2);
+
+            // Test 3: Test with advanced deduplication (automatic uniqueness and usages resolution)
+            var linksWithAdvancedDeduplication = links.DecorateWithAutomaticUniquenessAndUsagesResolution();
+            var sequenceWithAdvancedDedup1 = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+            var sequenceWithAdvancedDedup2 = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+
+            // With advanced deduplication, should also return same address
+            Assert.Equal(sequenceWithAdvancedDedup1, sequenceWithAdvancedDedup2);
+
+            // Test 4: Create longer sequences full of the same character
+            var longerSequence1 = links.CreateAndUpdate(character, sequenceWithoutDedup1);
+            var longerSequence2 = links.CreateAndUpdate(character, sequenceWithoutDedup1);
+
+            // Without deduplication, even with same elements, different addresses
+            Assert.NotEqual(longerSequence1, longerSequence2);
+
+            // Test 5: Test the same pattern with GetOrCreate for deduplication
+            var longerSequenceDedup1 = links.GetOrCreate(character, sequenceGetOrCreate1);
+            var longerSequenceDedup2 = links.GetOrCreate(character, sequenceGetOrCreate1);
+
+            // With GetOrCreate, same content should result in same address
+            Assert.Equal(longerSequenceDedup1, longerSequenceDedup2);
+
+            // Test 6: Verify that we can create sequences full of single character elements
+            // Create a sequence where both source and target are the same character
+            var singleCharSequence = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+            
+            // Create another sequence using the first sequence as source, character as target (building a chain)
+            var extendedSequence = linksWithAdvancedDeduplication.GetOrCreate(singleCharSequence, character);
+            
+            // Verify the sequence content
+            var singleCharSequenceLink = linksWithAdvancedDeduplication.GetLink(singleCharSequence);
+            Assert.Equal(character, linksWithAdvancedDeduplication.GetSource(singleCharSequenceLink));
+            Assert.Equal(character, linksWithAdvancedDeduplication.GetTarget(singleCharSequenceLink));
+            
+            var extendedSequenceLink = linksWithAdvancedDeduplication.GetLink(extendedSequence);
+            Assert.Equal(singleCharSequence, linksWithAdvancedDeduplication.GetSource(extendedSequenceLink));
+            Assert.Equal(character, linksWithAdvancedDeduplication.GetTarget(extendedSequenceLink));
+
+            // Test 7: Demonstrate sequence full of single character by creating repetitive patterns
+            // All these should be the same sequence since they have identical content
+            var repeatedCharSequence1 = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+            var repeatedCharSequence2 = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+            var repeatedCharSequence3 = linksWithAdvancedDeduplication.GetOrCreate(character, character);
+            
+            Assert.Equal(repeatedCharSequence1, repeatedCharSequence2);
+            Assert.Equal(repeatedCharSequence2, repeatedCharSequence3);
+
+            // The test demonstrates different deduplication methods for sequences of single characters:
+            // 1. CreateAndUpdate: Always creates new links (no deduplication)
+            // 2. GetOrCreate: Returns existing link if found, creates new if not (built-in deduplication)
+            // 3. Advanced deduplication decorators: Apply additional uniqueness and usage resolution
+        }
         private static void Using<TLinkAddress>(Action<ILinks<TLinkAddress>> action) where TLinkAddress  : IUnsignedNumber<TLinkAddress> , IShiftOperators<TLinkAddress,int,TLinkAddress>, IBitwiseOperators<TLinkAddress,TLinkAddress,TLinkAddress>, IMinMaxValue<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
         {
             var unitedMemoryLinks = new UnitedMemoryLinks<TLinkAddress>(new HeapResizableDirectMemory());

--- a/csharp/experiments/experiments.csproj
+++ b/csharp/experiments/experiments.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/experiments/debug_deduplication.cs
+++ b/experiments/debug_deduplication.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Platform.Data.Doublets.Decorators;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+
+namespace Platform.Data.Doublets.Experiments
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var memory = new HeapResizableDirectMemory();
+            var links = new UnitedMemoryLinks<uint>(memory);
+            
+            Console.WriteLine("=== WITHOUT DEDUPLICATION ===");
+            var character = links.CreatePoint();
+            Console.WriteLine($"Character: {character}");
+            
+            var seq1 = links.CreateAndUpdate(character, character);
+            var seq2 = links.CreateAndUpdate(character, character);
+            
+            Console.WriteLine($"Sequence 1: {seq1}");
+            Console.WriteLine($"Sequence 2: {seq2}");
+            Console.WriteLine($"Are they equal? {seq1 == seq2}");
+            Console.WriteLine($"Links count: {links.Count()}");
+            
+            Console.WriteLine("\n=== WITH BASIC DEDUPLICATION ===");
+            var linksWithDedup = new LinksUniquenessResolver<uint>(links);
+            
+            var dedupSeq1 = linksWithDedup.CreateAndUpdate(character, character);
+            var dedupSeq2 = linksWithDedup.CreateAndUpdate(character, character);
+            
+            Console.WriteLine($"Dedup Sequence 1: {dedupSeq1}");
+            Console.WriteLine($"Dedup Sequence 2: {dedupSeq2}");
+            Console.WriteLine($"Are they equal? {dedupSeq1 == dedupSeq2}");
+            Console.WriteLine($"Links count: {links.Count()}");
+            
+            // Test the advanced deduplication
+            Console.WriteLine("\n=== WITH ADVANCED DEDUPLICATION ===");
+            using var memory2 = new HeapResizableDirectMemory();
+            var links2 = new UnitedMemoryLinks<uint>(memory2);
+            var linksAdvanced = links2.DecorateWithAutomaticUniquenessAndUsagesResolution();
+            
+            var character2 = linksAdvanced.CreatePoint();
+            var advSeq1 = linksAdvanced.CreateAndUpdate(character2, character2);
+            var advSeq2 = linksAdvanced.CreateAndUpdate(character2, character2);
+            
+            Console.WriteLine($"Advanced Sequence 1: {advSeq1}");
+            Console.WriteLine($"Advanced Sequence 2: {advSeq2}");
+            Console.WriteLine($"Are they equal? {advSeq1 == advSeq2}");
+            Console.WriteLine($"Links count: {links2.Count()}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test that demonstrates creating sequences full of single character/element using different deduplication methods, as requested in issue #191.

## Changes

- Added  test method to 
- The test demonstrates 7 different scenarios:
  1. Creating sequences without deduplication using  - each identical link gets a unique address
  2. Using  for built-in deduplication - identical content returns the same address
  3. Testing advanced deduplication with 
  4. Creating longer sequences with single character elements
  5. Verifying deduplication behavior with longer sequences
  6. Creating and verifying sequences where both source and target are the same character
  7. Demonstrating repetitive pattern creation with deduplication

## Test Details

The test covers different deduplication methods:
- **No deduplication**:  always creates new links (different addresses for identical content)
- **Built-in deduplication**:  returns existing link if found, creates new if not
- **Advanced deduplication**: Uses decorators for additional uniqueness and usage resolution

## Test Results

✅ All tests pass for , , , and  address types

The test effectively demonstrates the differences between deduplication approaches when creating sequences of single characters/elements.

## Related Issue

Resolves #191

🤖 Generated with [Claude Code](https://claude.ai/code)