### PR TITLE
Add SplitMemoryLinks example to README documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/184
-Your prepared branch: issue-184-50380e1c
-Your prepared working directory: /tmp/gh-issue-solver-1757781696695
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/184
+Your prepared branch: issue-184-50380e1c
+Your prepared working directory: /tmp/gh-issue-solver-1757781696695
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,40 @@ link = links.Update(link, newSource: default, newTarget: default);
 links.Delete(link);
 ```
 
+## SplitMemoryLinks Example
+```C#
+using System;
+using Platform.Data;
+using Platform.Data.Doublets;
+using Platform.Data.Doublets.Memory.Split.Generic;
+
+// A doublet links store with separated data and index files:
+using var links = new SplitMemoryLinks<uint>("db-data.links", "db-index.links");
+
+// A creation of the doublet link: 
+var link = links.Create();
+
+// The link is updated to reference itself twice (as a source and a target):
+link = links.Update(link, newSource: link, newTarget: link);
+
+// Read operations:
+Console.WriteLine($"The number of links in the data store is {links.Count()}.");
+Console.WriteLine("Data store contents:");
+var any = links.Constants.Any; // Means any link address or no restriction on link address
+// Arguments of the query are interpreted as restrictions
+var query = new Link<uint>(index: any, source: any, target: any);
+links.Each((link) => {
+    Console.WriteLine(links.Format(link));
+    return links.Constants.Continue;
+}, query);
+
+// The link's content reset:
+link = links.Update(link, newSource: default, newTarget: default);
+
+// The link deletion:
+links.Delete(link);
+```
+
 ## [SQLite vs Doublets](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)
 
 [![Image with result of performance comparison between SQLite and Doublets.](https://raw.githubusercontent.com/linksplatform/Documentation/master/doc/Examples/sqlite_vs_doublets_performance.png "Result of performance comparison between SQLite and Doublets")](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)


### PR DESCRIPTION
## Summary

This PR adds a comprehensive SplitMemoryLinks usage example to the README documentation, addressing issue #184.

### Changes Made

- **Added SplitMemoryLinks Example**: A new code example demonstrating how to use `SplitMemoryLinks<uint>` alongside the existing `UnitedMemoryLinks` example
- **Key Differences Highlighted**: Shows that `SplitMemoryLinks` uses separate data and index files (`"db-data.links"`, `"db-index.links"`) compared to `UnitedMemoryLinks` which uses a single file
- **Complete CRUD Operations**: The example demonstrates:
  - Creating doublet links
  - Updating links to reference themselves
  - Reading and querying operations
  - Resetting link content
  - Deleting links
- **Consistent Documentation Style**: Follows the same pattern and structure as the existing `UnitedMemoryLinks` example

### Technical Details

The example shows the basic usage pattern:
```csharp
using var links = new SplitMemoryLinks<uint>("db-data.links", "db-index.links");
```

This demonstrates the key architectural difference where `SplitMemoryLinks` separates data storage from index storage, which can provide performance benefits in certain scenarios.

### Testing

- Created and validated a working test to ensure the example code compiles and runs correctly
- Verified that all CRUD operations work as expected
- Confirmed the example follows the existing code style and conventions

Fixes #184

🤖 Generated with [Claude Code](https://claude.ai/code)