### PR TITLE
Update code examples in documentation to match current Examples.Doublets.CRUD repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/183
-Your prepared branch: issue-183-65fb60df
-Your prepared working directory: /tmp/gh-issue-solver-1757782177080
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/183
+Your prepared branch: issue-183-65fb60df
+Your prepared working directory: /tmp/gh-issue-solver-1757782177080
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -14,38 +14,44 @@ Forked from: [Konard/LinksPlatform/Platform/Platform.Data.Doublets](https://gith
 
 NuGet package: [Platform.Data.Doublets](https://www.nuget.org/packages/Platform.Data.Doublets)
 
-## [Example](https://github.com/linksplatform/Examples.Doublets.CRUD.DotNet) | [Run .NET fiddle](https://dotnetfiddle.net/Y7Zvt0)
+## [Example](https://github.com/linksplatform/Examples.Doublets.CRUD) | [Run .NET fiddle](https://dotnetfiddle.net/Y7Zvt0)
 ```C#
 using System;
 using Platform.Data;
 using Platform.Data.Doublets;
 using Platform.Data.Doublets.Memory.United.Generic;
 
-// A doublet links store is mapped to "db.links" file:
-using var links = new UnitedMemoryLinks<uint>("db.links");
+class Program
+{
+    static void Main(string[] args)
+    {
+        // A doublet links store is mapped to the "db.links" file:
+        using var links = new UnitedMemoryLinks<uint>("db.links");
 
-// A creation of the doublet link: 
-var link = links.Create();
+        // Creating a doublet link: 
+        var link = links.Create();
 
-// The link is updated to reference itself twice (as a source and a target):
-link = links.Update(link, newSource: link, newTarget: link);
+        // The link is updated to reference itself twice (as a source and as a target):
+        link = links.Update(link, newSource: link, newTarget: link);
 
-// Read operations:
-Console.WriteLine($"The number of links in the data store is {links.Count()}.");
-Console.WriteLine("Data store contents:");
-var any = links.Constants.Any; // Means any link address or no restriction on link address
-// Arguments of the query are interpreted as restrictions
-var query = new Link<uint>(index: any, source: any, target: any);
-links.Each((link) => {
-    Console.WriteLine(links.Format(link));
-    return links.Constants.Continue;
-}, query);
+        // Read operations:
+        Console.WriteLine($"The number of links in the data store is {links.Count()}.");
+        Console.WriteLine("Data store contents:");
+        
+        var any = links.Constants.Any; 
+        var query = new Link<uint>(index: any, source: any, target: any);
+        links.Each((link) => {
+            Console.WriteLine(links.Format(link));
+            return links.Constants.Continue;
+        }, query);
 
-// The link's content reset:
-link = links.Update(link, newSource: default, newTarget: default);
+        // Cleaning (resetting) the contents of the link:
+        link = links.Update(link, newSource: default, newTarget: default);
 
-// The link deletion:
-links.Delete(link);
+        // Removing the link
+        links.Delete(link);
+    }
+}
 ```
 
 ## [SQLite vs Doublets](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)

--- a/README.ru.md
+++ b/README.ru.md
@@ -12,38 +12,44 @@
 
 NuGet пакет: [Platform.Data.Doublets](https://www.nuget.org/packages/Platform.Data.Doublets)
 
-## [Пример](https://github.com/linksplatform/Examples.Doublets.CRUD.DotNet) | [Запустить .NET fiddle](https://dotnetfiddle.net/Y7Zvt0)
+## [Пример](https://github.com/linksplatform/Examples.Doublets.CRUD) | [Запустить .NET fiddle](https://dotnetfiddle.net/Y7Zvt0)
 ```C#
 using System;
 using Platform.Data;
 using Platform.Data.Doublets;
 using Platform.Data.Doublets.Memory.United.Generic;
 
-// Хранилище дуплетов привязывается к файлу "db.links":
-using var links = new UnitedMemoryLinks<uint>("db.links");
+class Program
+{
+    static void Main(string[] args)
+    {
+        // Хранилище дуплетов привязывается к файлу "db.links":
+        using var links = new UnitedMemoryLinks<uint>("db.links");
 
-// Создание связи-дуплета: 
-var link = links.Create();
+        // Создание связи-дуплета: 
+        var link = links.Create();
 
-// Связь обновляется чтобы ссылаться на себя дважды (в качестве начала и конца):
-link = links.Update(link, newSource: link, newTarget: link);
+        // Связь обновляется чтобы ссылаться на себя дважды (в качестве начала и конца):
+        link = links.Update(link, newSource: link, newTarget: link);
 
-// Операции чтения:
-Console.WriteLine($"Количество связей в хранилище данных: {links.Count()}.");
-Console.WriteLine("Содержимое хранилища данных:");
-var any = links.Constants.Any; // Означает любой адрес связи или отсутствие ограничения на адрес связи
-// Аргументы запроса интерпретируются в качестве органичений
-var query = new Link<uint>(index: any, source: any, target: any);
-links.Each((link) => {
-    Console.WriteLine(links.Format(link));
-    return links.Constants.Continue;
-}, query);
+        // Операции чтения:
+        Console.WriteLine($"Количество связей в хранилище данных: {links.Count()}.");
+        Console.WriteLine("Содержимое хранилища данных:");
+        
+        var any = links.Constants.Any; 
+        var query = new Link<uint>(index: any, source: any, target: any);
+        links.Each((link) => {
+            Console.WriteLine(links.Format(link));
+            return links.Constants.Continue;
+        }, query);
 
-// Сброс содержимого связи:
-link = links.Update(link, newSource: default, newTarget: default);
+        // Очистка (сброс) содержимого связи:
+        link = links.Update(link, newSource: default, newTarget: default);
 
-// Удаление связи:
-links.Delete(link);
+        // Удаление связи
+        links.Delete(link);
+    }
+}
 ```
 
 ## [SQLite против Дуплетов](https://github.com/linksplatform/Comparisons.SQLiteVSDoublets)


### PR DESCRIPTION
## Summary
- Updated C# code example in both README.md and README.ru.md to match the current Examples.Doublets.CRUD repository
- Added proper class structure with Main method wrapper 
- Updated repository links from Examples.Doublets.CRUD.DotNet to Examples.Doublets.CRUD
- Improved comments and code structure to match the latest HelloWorld example
- Maintained consistency between English and Russian documentation

## Changes Made
- **README.md**: Updated the C# example code with proper class structure and current repository reference
- **README.ru.md**: Updated the Russian version of the C# example code with proper class structure and current repository reference
- **Repository Links**: Changed from `Examples.Doublets.CRUD.DotNet` to `Examples.Doublets.CRUD` to match the actual repository name

## Test plan
- [x] Verified that the new example code matches the current Examples.Doublets.CRUD repository
- [x] Ensured consistency between English and Russian documentation
- [x] Confirmed all repository links are correct and functional

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #183