### PR TITLE
Improve error messages when database access is disposed (#174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/174
-Your prepared branch: issue-174-38feee43
-Your prepared working directory: /tmp/gh-issue-solver-1757790852962
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/174
+Your prepared branch: issue-174-38feee43
+Your prepared working directory: /tmp/gh-issue-solver-1757790852962
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/DisposalErrorMessagesTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/DisposalErrorMessagesTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Xunit;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+
+namespace Platform.Data.Doublets.Tests
+{
+    /// <summary>
+    /// Tests to verify that better error messages are shown when database access is disposed
+    /// right after the access is created (GitHub issue #174)
+    /// </summary>
+    public static class DisposalErrorMessagesTests
+    {
+        [Fact]
+        public static void DisposedLinksThrowObjectDisposedExceptionWithMeaningfulMessage()
+        {
+            var links = new UnitedMemoryLinks<uint>(new HeapResizableDirectMemory());
+            
+            // Create a link and then dispose
+            var link = links.Create();
+            links.Dispose();
+            
+            // Test Count method
+            var ex = Assert.Throws<ObjectDisposedException>(() => links.Count());
+            Assert.Contains("Cannot access a disposed Links instance", ex.Message);
+            Assert.Contains("database connection has been closed", ex.Message);
+            
+            // Test Create method
+            ex = Assert.Throws<ObjectDisposedException>(() => links.Create());
+            Assert.Contains("Cannot access a disposed Links instance", ex.Message);
+            
+            // Test Delete method
+            ex = Assert.Throws<ObjectDisposedException>(() => links.Delete(link));
+            Assert.Contains("Cannot access a disposed Links instance", ex.Message);
+            
+            // Test Each method  
+            ex = Assert.Throws<ObjectDisposedException>(() => links.Each(handler: l => links.Constants.Continue));
+            Assert.Contains("Cannot access a disposed Links instance", ex.Message);
+            
+            // Test Update method
+            ex = Assert.Throws<ObjectDisposedException>(() => links.Update(new[] { link }, new[] { link }));
+            Assert.Contains("Cannot access a disposed Links instance", ex.Message);
+        }
+        
+        [Fact]
+        public static void DisposedLinksObjectNameIsCorrectInException()
+        {
+            var links = new UnitedMemoryLinks<uint>(new HeapResizableDirectMemory());
+            links.Dispose();
+            
+            var ex = Assert.Throws<ObjectDisposedException>(() => links.Count());
+            Assert.Contains("UnitedMemoryLinks", ex.ObjectName);
+        }
+        
+        [Fact] 
+        public static void NonDisposedLinksWorkNormally()
+        {
+            using var links = new UnitedMemoryLinks<uint>(new HeapResizableDirectMemory());
+            
+            // These should all work normally without throwing ObjectDisposedException
+            var count = links.Count();
+            var link = links.Create();
+            links.Each(handler: l => links.Constants.Continue);
+            // Test update - create another link to update the first one
+            var link2 = links.Create();
+            links.Update(new[] { link }, new[] { link, link2, link2 });
+            links.Delete(link);
+            links.Delete(link2);
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/Ffi/Links.cs
+++ b/csharp/Platform.Data.Doublets/Ffi/Links.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Platform.Converters;
 using Platform.Delegates;
@@ -181,6 +182,25 @@ namespace Platform.Data.Doublets.Ffi
 
         private readonly unsafe void* _ptr;
 
+        /// <summary>
+        ///     <para>
+        ///         Ensures that this instance has not been disposed.
+        ///     </para>
+        ///     <para></para>
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        ///     <para>Thrown when this instance has been disposed.</para>
+        ///     <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected virtual void EnsureNotDisposed()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name, "Cannot access a disposed Links instance. The database connection has been closed and is no longer available for operations.");
+            }
+        }
+
         public Links(string path)
         {
             TLinkAddress t = default;
@@ -202,6 +222,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Count(IList<TLinkAddress>? restriction)
         {
+            EnsureNotDisposed();
             var restrictionLength = restriction?.Count ?? 0;
             unsafe
             {
@@ -260,6 +281,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var restrictionLength = restriction?.Count ?? 0;
             unsafe
             {
@@ -322,6 +344,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var substitutionLength = substitution?.Count ?? 0;
             unsafe
             {
@@ -384,6 +407,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var restrictionLength = restriction?.Count ?? 0;
             var substitutionLength = substitution?.Count ?? 0;
             unsafe
@@ -469,6 +493,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var restrictionLength = restriction?.Count ?? 0;
             unsafe
             {

--- a/csharp/Platform.Data.Doublets/Ffi/UInt32Links.cs
+++ b/csharp/Platform.Data.Doublets/Ffi/UInt32Links.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Platform.Converters;
 using Platform.Delegates;
@@ -17,6 +18,25 @@ namespace Platform.Data.Doublets.Ffi
 
         private readonly unsafe void* _ptr;
 
+        /// <summary>
+        ///     <para>
+        ///         Ensures that this instance has not been disposed.
+        ///     </para>
+        ///     <para></para>
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        ///     <para>Thrown when this instance has been disposed.</para>
+        ///     <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected virtual void EnsureNotDisposed()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name, "Cannot access a disposed Links instance. The database connection has been closed and is no longer available for operations.");
+            }
+        }
+
         public UInt32Links(string path)
         {
             unsafe
@@ -30,6 +50,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Count(IList<TLinkAddress>? restriction)
         {
+            EnsureNotDisposed();
             unsafe
             {
                 var array = stackalloc uint[restriction.Count];
@@ -43,6 +64,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             unsafe
             {
                 Methods.EachCallback_UInt32 callback = (link) => handler != null ? handler(new Link<TLinkAddress>(link.Index, link.Source, link.Target)) : Constants.Continue;
@@ -57,6 +79,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             unsafe
             {
                 Methods.CreateCallback_UInt32 callback = (before, after) => handler != null ? handler(new Link<TLinkAddress>(before.Index, before.Source, before.Target), new Link<TLinkAddress>(after.Index, after.Source, after.Target)) : Constants.Continue;
@@ -69,6 +92,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             unsafe
             {
                 var restrictionArray = stackalloc uint[restriction.Count];
@@ -88,6 +112,7 @@ namespace Platform.Data.Doublets.Ffi
 
         public TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             unsafe
             {
                 var restrictionArray = stackalloc uint[restriction.Count];

--- a/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
@@ -223,6 +223,25 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
 
     /// <summary>
     ///     <para>
+    ///         Ensures that this instance has not been disposed.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     <para>Thrown when this instance has been disposed.</para>
+    ///     <para></para>
+    /// </exception>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    protected virtual void EnsureNotDisposed()
+    {
+        if (IsDisposed)
+        {
+            throw new ObjectDisposedException(GetType().Name, "Cannot access a disposed Links instance. The database connection has been closed and is no longer available for operations.");
+        }
+    }
+
+    /// <summary>
+    ///     <para>
     ///         Counts the substitution.
     ///     </para>
     ///     <para></para>
@@ -242,6 +261,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     public virtual TLinkAddress Count(IList<TLinkAddress>? restriction)
     {
+        EnsureNotDisposed();
         // Если нет ограничений, тогда возвращаем общее число связей находящихся в хранилище.
         if (restriction.Count == 0)
         {
@@ -433,6 +453,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     public virtual TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler)
     {
+        EnsureNotDisposed();
         var constants = Constants;
         var @break = constants.Break;
         if (restriction.Count == 0)
@@ -612,6 +633,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     public virtual TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
     {
+        EnsureNotDisposed();
         var constants = Constants;
         var @null = constants.Null;
         var externalReferencesRange = constants.ExternalReferencesRange;
@@ -693,6 +715,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     public virtual TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
     {
+        EnsureNotDisposed();
         ref var header = ref GetHeaderReference();
         var freeLink = header.FirstFreeLink;
         if ((freeLink != Constants.Null))
@@ -734,6 +757,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
     public virtual TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler)
     {
+        EnsureNotDisposed();
         ref var header = ref GetHeaderReference();
         var link = restriction[index: Constants.IndexPart];
         var before = GetLinkStruct(linkIndex: link);

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
@@ -115,6 +115,25 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         }
 
         /// <summary>
+        ///     <para>
+        ///         Ensures that this instance has not been disposed.
+        ///     </para>
+        ///     <para></para>
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">
+        ///     <para>Thrown when this instance has been disposed.</para>
+        ///     <para></para>
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected virtual void EnsureNotDisposed()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name, "Cannot access a disposed Links instance. The database connection has been closed and is no longer available for operations.");
+            }
+        }
+
+        /// <summary>
         /// <para>
         /// Initializes a new <see cref="UnitedMemoryLinksBase"/> instance.
         /// </para>
@@ -207,6 +226,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual TLinkAddress Count(IList<TLinkAddress>? restriction)
         {
+            EnsureNotDisposed();
             // Если нет ограничений, тогда возвращаем общее число связей находящихся в хранилище.
             if (restriction.Count == 0)
             {
@@ -340,6 +360,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual TLinkAddress Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var constants = Constants;
             var @break = constants.Break;
             if (restriction.Count == 0)
@@ -472,6 +493,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual TLinkAddress Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             var constants = Constants;
             var @null = constants.Null;
             var linkIndex = this.GetIndex(restriction);
@@ -508,6 +530,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual TLinkAddress Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             ref var header = ref GetHeaderReference();
             var freeLink = header.FirstFreeLink;
             if (!AreEqual(freeLink, Constants.Null))
@@ -547,6 +570,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual TLinkAddress Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler)
         {
+            EnsureNotDisposed();
             ref var header = ref GetHeaderReference();
             var link = restriction[Constants.IndexPart];
             var before = GetLinkStruct(link);

--- a/experiments/DisposalTest.cs
+++ b/experiments/DisposalTest.cs
@@ -1,0 +1,51 @@
+using System;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+
+namespace Platform.Data.Doublets.Experiments
+{
+    /// <summary>
+    /// Experiment to test the improved disposal error messaging for GitHub issue #174
+    /// </summary>
+    public static class DisposalTest
+    {
+        public static void TestImprovedErrorMessagesAfterDisposal()
+        {
+            var links = new UnitedMemoryLinks<uint>(new HeapResizableDirectMemory());
+            
+            // Use the links normally
+            var link = links.Create();
+            Console.WriteLine($"Created link: {link}");
+            
+            // Dispose the links
+            links.Dispose();
+            Console.WriteLine("Links have been disposed.");
+            
+            // Test improved error messages for various operations
+            TestOperation("Count()", () => links.Count());
+            TestOperation("Create()", () => links.Create());
+            TestOperation("Delete(link)", () => links.Delete(link));
+            TestOperation("Each() with callback", () => links.Each(handler: link => link.Index));
+            TestOperation("Update()", () => links.Update(new[] { link }, new[] { link }));
+        }
+        
+        private static void TestOperation(string operationName, Action operation)
+        {
+            try
+            {
+                operation();
+                Console.WriteLine($"ERROR: {operationName} should have thrown ObjectDisposedException!");
+            }
+            catch (ObjectDisposedException ex)
+            {
+                Console.WriteLine($"✓ {operationName}: Correctly threw ObjectDisposedException");
+                Console.WriteLine($"  Object: {ex.ObjectName}");
+                Console.WriteLine($"  Message: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"✗ {operationName}: Threw unexpected exception - {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes GitHub issue #174 by implementing better error messages when database access is disposed right after the access is created.

### Problem
Previously, when a `Links` instance was disposed and users tried to access database methods (`Count()`, `Create()`, `Update()`, `Delete()`, `Each()`), they would encounter:
- Generic null reference exceptions
- Access violations  
- Non-descriptive error messages
- Crashes with unclear stack traces

This made debugging difficult for users who accidentally tried to use disposed database connections.

### Solution
Added comprehensive disposal checking to all public database access methods across all `Links` implementations:

**Key Changes:**
- **Added `EnsureNotDisposed()` method** to all Links base classes:
  - `UnitedMemoryLinksBase<T>`
  - `SplitMemoryLinksBase<T>`
  - `Links<T>` (FFI)
  - `UInt32Links` (FFI)

- **Clear, descriptive error message:**
  ```
  "Cannot access a disposed Links instance. The database connection has been closed and is no longer available for operations."
  ```

- **Applied to all public methods:**
  - `Count(IList<TLinkAddress>? restriction)`
  - `Create(IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)`
  - `Update(IList<TLinkAddress>? restriction, IList<TLinkAddress>? substitution, WriteHandler<TLinkAddress>? handler)`
  - `Delete(IList<TLinkAddress>? restriction, WriteHandler<TLinkAddress>? handler)`
  - `Each(IList<TLinkAddress>? restriction, ReadHandler<TLinkAddress>? handler)`

### Testing
- **Added comprehensive test suite** (`DisposalErrorMessagesTests.cs`) that verifies:
  - All methods throw `ObjectDisposedException` when called on disposed instances
  - Exception messages contain meaningful descriptions
  - Object names are correctly included in exceptions
  - Non-disposed instances continue to work normally
- **All existing tests pass** - no regressions introduced

### Example Usage
**Before (unclear error):**
```csharp
var links = new UnitedMemoryLinks<uint>(memory);
links.Dispose();
var count = links.Count(); // NullReferenceException or similar
```

**After (clear error):**
```csharp
var links = new UnitedMemoryLinks<uint>(memory);
links.Dispose();
var count = links.Count(); 
// ObjectDisposedException: Cannot access a disposed Links instance. 
// The database connection has been closed and is no longer available for operations.
```

### Impact
- **Better Developer Experience:** Users get immediate, clear feedback when they accidentally use disposed connections
- **Easier Debugging:** Error messages explain exactly what's wrong and what needs to be fixed
- **Consistent Behavior:** All Links implementations now behave the same way when disposed
- **Zero Breaking Changes:** Only adds new error checking, doesn't change existing functionality

## Test plan
- [x] All existing unit tests pass
- [x] New disposal error tests pass
- [x] Manual testing with disposed instances shows improved error messages
- [x] Build succeeds with no warnings or errors

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #174