### PR TITLE
Enable external references by default in all memory adapters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/155
+Your prepared branch: issue-155-6f3abe86
+Your prepared working directory: /tmp/gh-issue-solver-1757813207020
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/155
-Your prepared branch: issue-155-6f3abe86
-Your prepared working directory: /tmp/gh-issue-solver-1757813207020
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/ResizableDirectMemoryLinksTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/ResizableDirectMemoryLinksTests.cs
@@ -8,7 +8,7 @@ namespace Platform.Data.Doublets.Tests
 {
     public static class ResizableDirectMemoryLinksTests
     {
-        private static readonly LinksConstants<ulong> _constants = Default<LinksConstants<ulong>>.Instance;
+        private static readonly LinksConstants<ulong> _constants = new LinksConstants<ulong>(enableExternalReferencesSupport: true);
 
         [Fact]
         public static void BasicFileMappedMemoryTest()

--- a/csharp/Platform.Data.Doublets/Link.cs
+++ b/csharp/Platform.Data.Doublets/Link.cs
@@ -24,7 +24,7 @@ namespace Platform.Data.Doublets
         /// <para></para>
         /// </summary>
         public static readonly Link<TLinkAddress> Null = new Link<TLinkAddress>();
-        private static readonly LinksConstants<TLinkAddress> _constants = Default<LinksConstants<TLinkAddress>>.Instance;
+        private static readonly LinksConstants<TLinkAddress> _constants = new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true);
         private const int Length = 3;
 
         /// <summary>

--- a/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs
+++ b/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs
@@ -79,7 +79,7 @@ public unsafe class SplitMemoryLinks<TLinkAddress> : SplitMemoryLinksBase<TLinkA
     ///     <para></para>
     /// </param>
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-    public SplitMemoryLinks(IResizableDirectMemory dataMemory, IResizableDirectMemory indexMemory, long memoryReservationStep) : this(dataMemory: dataMemory, indexMemory: indexMemory, memoryReservationStep: memoryReservationStep, constants: Default<LinksConstants<TLinkAddress>>.Instance, indexTreeType: IndexTreeType.Default, useLinkedList: true) { }
+    public SplitMemoryLinks(IResizableDirectMemory dataMemory, IResizableDirectMemory indexMemory, long memoryReservationStep) : this(dataMemory: dataMemory, indexMemory: indexMemory, memoryReservationStep: memoryReservationStep, constants: new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true), indexTreeType: IndexTreeType.Default, useLinkedList: true) { }
 
     /// <summary>
     ///     <para>

--- a/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs
@@ -194,7 +194,7 @@ public abstract class SplitMemoryLinksBase<TLinkAddress> : DisposableBase, ILink
     ///     <para></para>
     /// </param>
     [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-    protected SplitMemoryLinksBase(IResizableDirectMemory dataMemory, IResizableDirectMemory indexMemory, long memoryReservationStep) : this(dataMemory: dataMemory, indexMemory: indexMemory, memoryReservationStep: memoryReservationStep, constants: Default<LinksConstants<TLinkAddress>>.Instance, useLinkedList: true) { }
+    protected SplitMemoryLinksBase(IResizableDirectMemory dataMemory, IResizableDirectMemory indexMemory, long memoryReservationStep) : this(dataMemory: dataMemory, indexMemory: indexMemory, memoryReservationStep: memoryReservationStep, constants: new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true), useLinkedList: true) { }
 
     /// <summary>
     ///     Возвращает общее число связей находящихся в хранилище.

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs
@@ -72,7 +72,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public UnitedMemoryLinks(IResizableDirectMemory memory, long memoryReservationStep) : this(memory, memoryReservationStep, Default<LinksConstants<TLinkAddress>>.Instance, IndexTreeType.Default) { }
+        public UnitedMemoryLinks(IResizableDirectMemory memory, long memoryReservationStep) : this(memory, memoryReservationStep, new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true), IndexTreeType.Default) { }
 
         /// <summary>
         /// <para>

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs
@@ -155,7 +155,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected UnitedMemoryLinksBase(IResizableDirectMemory memory, long memoryReservationStep) : this(memory, memoryReservationStep, Default<LinksConstants<TLinkAddress>>.Instance) { }
+        protected UnitedMemoryLinksBase(IResizableDirectMemory memory, long memoryReservationStep) : this(memory, memoryReservationStep, new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true)) { }
 
         /// <summary>
         /// <para>


### PR DESCRIPTION
## Summary

This PR addresses issue #155 by enabling external references support by default in all memory adapter classes.

- ✅ Updated `SplitMemoryLinksBase` to enable external references by default
- ✅ Updated `SplitMemoryLinks` to enable external references by default  
- ✅ Updated `UnitedMemoryLinks` to enable external references by default
- ✅ Updated `UnitedMemoryLinksBase` to enable external references by default
- ✅ Updated `Link` class to enable external references by default
- ✅ Updated test constants to maintain consistency
- ✅ All tests pass with the new configuration

## Changes Made

Instead of using `Default<LinksConstants<TLinkAddress>>.Instance` (which disables external references), all memory adapters now use `new LinksConstants<TLinkAddress>(enableExternalReferencesSupport: true)` as their default configuration.

This provides better out-of-the-box functionality for users who need external references support, which is now the default behavior across all memory adapters.

## Test Plan

- [x] All existing tests pass
- [x] Updated test constants to use consistent configuration
- [x] No breaking changes to existing API surface

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/code)