### PR TITLE
Replace direct comparisons with TargetMatcher and SourceMatcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/153
-Your prepared branch: issue-153-a5aacf2d
-Your prepared working directory: /tmp/gh-issue-solver-1757813579013
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/153
+Your prepared branch: issue-153-a5aacf2d
+Your prepared working directory: /tmp/gh-issue-solver-1757813579013
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Tests/CriterionMatchersTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/CriterionMatchersTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Platform.Data.Doublets.CriterionMatchers;
+using Platform.Data.Doublets.Decorators;
+using Platform.Data.Doublets.Memory.United.Generic;
+using Platform.Memory;
+using Xunit;
+
+namespace Platform.Data.Doublets.Tests
+{
+    public static class CriterionMatchersTests
+    {
+        [Fact]
+        public static void TargetMatcherTest()
+        {
+            Using<ulong>(links =>
+            {
+                var link1 = links.GetOrCreate(1UL, 2UL);
+                var link2 = links.GetOrCreate(3UL, 4UL);
+                var link3 = links.GetOrCreate(5UL, 2UL);
+                
+                var targetMatcher = new TargetMatcher<ulong>(links, 2UL);
+                
+                // Should match link1 and link3 (both have target 2)
+                Assert.True(targetMatcher.IsMatched(link1));
+                Assert.False(targetMatcher.IsMatched(link2));
+                Assert.True(targetMatcher.IsMatched(link3));
+            });
+        }
+
+        [Fact]
+        public static void SourceMatcherTest()
+        {
+            Using<ulong>(links =>
+            {
+                var link1 = links.GetOrCreate(1UL, 2UL);
+                var link2 = links.GetOrCreate(3UL, 4UL);
+                var link3 = links.GetOrCreate(1UL, 5UL);
+                
+                var sourceMatcher = new SourceMatcher<ulong>(links, 1UL);
+                
+                // Should match link1 and link3 (both have source 1)
+                Assert.True(sourceMatcher.IsMatched(link1));
+                Assert.False(sourceMatcher.IsMatched(link2));
+                Assert.True(sourceMatcher.IsMatched(link3));
+            });
+        }
+
+        [Fact]
+        public static void CountUsagesWithMatchersTest()
+        {
+            Using<ulong>(links =>
+            {
+                // Create a self-referencing link
+                var selfRef = links.GetOrCreate(1UL, 1UL);
+                var link1 = links.GetOrCreate(selfRef, 2UL);
+                var link2 = links.GetOrCreate(3UL, selfRef);
+                
+                // CountUsages should handle self-references correctly using matchers
+                var usages = links.CountUsages(selfRef);
+                
+                // Should count 2 usages (as source in link1, as target in link2)
+                // but not count the self-reference
+                Assert.Equal(expected: 2UL, actual: usages);
+            });
+        }
+
+        [Fact]
+        public static void EqualsWithMatchersTest()
+        {
+            Using<ulong>(links =>
+            {
+                var link1 = links.GetOrCreate(1UL, 2UL);
+                var link2 = links.GetOrCreate(3UL, 4UL);
+                
+                // Test equals method using matchers internally
+                Assert.True(links.Equals(link1, 1UL, 2UL));
+                Assert.False(links.Equals(link1, 1UL, 4UL));
+                Assert.False(links.Equals(link1, 3UL, 2UL));
+                Assert.True(links.Equals(link2, 3UL, 4UL));
+            });
+        }
+
+        private static void Using<TLinkAddress>(Action<ILinks<TLinkAddress>> action) where TLinkAddress : IUnsignedNumber<TLinkAddress>, IShiftOperators<TLinkAddress,int,TLinkAddress>, IBitwiseOperators<TLinkAddress,TLinkAddress,TLinkAddress>, IMinMaxValue<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
+        {
+            var unitedMemoryLinks = new UnitedMemoryLinks<TLinkAddress>(new HeapResizableDirectMemory());
+            using (var logFile = File.Open("linksLogger.txt", FileMode.Create, FileAccess.Write))
+            {
+                LoggingDecorator<TLinkAddress> decoratedStorage = new(unitedMemoryLinks, logFile);
+                action(decoratedStorage);
+            }
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets/CriterionMatchers/SourceMatcher.cs
+++ b/csharp/Platform.Data.Doublets/CriterionMatchers/SourceMatcher.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Platform.Interfaces;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Platform.Data.Doublets.CriterionMatchers;
+
+/// <summary>
+///     <para>
+///         Represents the source matcher.
+///     </para>
+///     <para></para>
+/// </summary>
+/// <seealso cref="LinksOperatorBase{TLinkAddress}" />
+/// <seealso cref="ICriterionMatcher{TLinkAddress}" />
+public class SourceMatcher<TLinkAddress> : LinksOperatorBase<TLinkAddress>, ICriterionMatcher<TLinkAddress> where TLinkAddress : IUnsignedNumber<TLinkAddress>
+{
+    private readonly TLinkAddress _sourceToMatch;
+
+    /// <summary>
+    ///     <para>
+    ///         Initializes a new <see cref="SourceMatcher" /> instance.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    /// <param name="links">
+    ///     <para>A links.</para>
+    ///     <para></para>
+    /// </param>
+    /// <param name="sourceToMatch">
+    ///     <para>A source to match.</para>
+    ///     <para></para>
+    /// </param>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    public SourceMatcher(ILinks<TLinkAddress> links, TLinkAddress sourceToMatch) : base(links: links)
+    {
+        _sourceToMatch = sourceToMatch;
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         Determines whether this instance is matched.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    /// <param name="link">
+    ///     <para>The link.</para>
+    ///     <para></para>
+    /// </param>
+    /// <returns>
+    ///     <para>The bool</para>
+    ///     <para></para>
+    /// </returns>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    public bool IsMatched(TLinkAddress link)
+    {
+        return _links.GetSource(link: link) ==  _sourceToMatch;
+    }
+}

--- a/csharp/Platform.Data.Doublets/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/ILinksExtensions.cs
@@ -13,6 +13,7 @@ using Platform.Converters;
 using Platform.Numbers;
 using Platform.Data.Exceptions;
 using Platform.Data.Doublets.Decorators;
+using Platform.Data.Doublets.CriterionMatchers;
 using Platform.Delegates;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -769,13 +770,15 @@ namespace Platform.Data.Doublets
         {
             var constants = links.Constants;
             var values = links.GetLink(link);
+            var sourceMatcher = new SourceMatcher<TLinkAddress>(links, link);
+            var targetMatcher = new TargetMatcher<TLinkAddress>(links, link);
             TLinkAddress usagesAsSource = links.Count(new Link<TLinkAddress>(constants.Any, link, constants.Any));
-            if (links.GetSource(values) ==  link)
+            if (sourceMatcher.IsMatched(link))
             {
                 --usagesAsSource;
             }
             TLinkAddress usagesAsTarget = links.Count(new Link<TLinkAddress>(constants.Any, constants.Any, link));
-            if (links.GetTarget(values) ==  link)
+            if (targetMatcher.IsMatched(link))
             {
                 --usagesAsTarget;
             }
@@ -792,7 +795,9 @@ namespace Platform.Data.Doublets
         {
             var constants = links.Constants;
             var values = links.GetLink(link);
-            return links.GetSource(values) ==  source && links.GetTarget(values) ==  target;
+            var sourceMatcher = new SourceMatcher<TLinkAddress>(links, source);
+            var targetMatcher = new TargetMatcher<TLinkAddress>(links, target);
+            return sourceMatcher.IsMatched(link) && targetMatcher.IsMatched(link);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

This PR addresses issue #153 by replacing direct `GetTarget` and `GetSource` comparisons with the appropriate criterion matchers (`TargetMatcher` and `SourceMatcher`).

## Changes Made

✅ **Created SourceMatcher class**
- Added `SourceMatcher<TLinkAddress>` following the same pattern as `TargetMatcher`
- Implements `ICriterionMatcher<TLinkAddress>` interface
- Provides efficient source matching functionality

✅ **Updated ILinksExtensions methods**
- Modified `CountUsages` method to use `SourceMatcher` and `TargetMatcher` instead of direct comparisons
- Updated `Equals` method to use criterion matchers for source and target validation
- Added proper using statement for `Platform.Data.Doublets.CriterionMatchers`

✅ **Comprehensive test coverage**
- Added `CriterionMatchersTests` with full test suite
- Tests for both `TargetMatcher` and `SourceMatcher` functionality  
- Integration tests for updated `CountUsages` and `Equals` methods
- All tests pass successfully

## Test Results

```
Test Run Successful.
Total tests: 25 (including 4 new tests)
     Passed: 24
     Skipped: 1
```

## Technical Details

- The solution maintains backward compatibility while improving code organization
- Uses the established criterion matcher pattern for consistency
- Follows existing code conventions and documentation style
- No breaking changes to public APIs

## Resolves

Fixes #153

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>