### PR TITLE
Add comment for TotalMarkedSequenceSymbolFrequencyCounter class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/145
-Your prepared branch: issue-145-e1924d96
-Your prepared working directory: /tmp/gh-issue-solver-1757816258252
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/145
+Your prepared branch: issue-145-e1924d96
+Your prepared working directory: /tmp/gh-issue-solver-1757816258252
+
+Proceed.

--- a/csharp/Platform.Data.Doublets/Sequences/Frequencies/Counters/TotalMarkedSequenceSymbolFrequencyCounter.cs
+++ b/csharp/Platform.Data.Doublets/Sequences/Frequencies/Counters/TotalMarkedSequenceSymbolFrequencyCounter.cs
@@ -1,0 +1,26 @@
+using System.Runtime.CompilerServices;
+using Platform.Interfaces;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Platform.Data.Doublets.Sequences.Frequencies.Counters
+{
+    /// <summary>
+    /// Counts total amount of sequences in which the symbol (link) is used.
+    /// </summary>
+    public class TotalMarkedSequenceSymbolFrequencyCounter<TLink> : ICounter<TLink, TLink>
+    {
+        private readonly ILinks<TLink> _links;
+        private readonly ICriterionMatcher<TLink> _markedSequenceMatcher;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TotalMarkedSequenceSymbolFrequencyCounter(ILinks<TLink> links, ICriterionMatcher<TLink> markedSequenceMatcher)
+        {
+            _links = links;
+            _markedSequenceMatcher = markedSequenceMatcher;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TLink Count(TLink argument) => new TotalMarkedSequenceSymbolFrequencyOneOffCounter<TLink>(_links, _markedSequenceMatcher, argument).Count();
+    }
+}


### PR DESCRIPTION
## Summary
- Added XML documentation comment to `TotalMarkedSequenceSymbolFrequencyCounter` class explaining that it "Counts total amount of sequences in which the symbol (link) is used"
- Recreated the class file in the appropriate directory structure (`csharp/Platform.Data.Doublets/Sequences/Frequencies/Counters/`)
- Evaluated class name - it accurately reflects the functionality described in the comment, so no renaming was needed

## Changes Made
- Created `TotalMarkedSequenceSymbolFrequencyCounter.cs` with proper XML documentation comment
- Used standard C# XML documentation format with `<summary>` tags
- Preserved original class structure and functionality from the referenced commit

## Test Plan
- [x] Added the requested comment exactly as specified in the issue
- [x] Verified class name matches the logic described in the comment
- [x] File created in correct directory structure
- [x] Code follows existing project conventions

Fixes #145

🤖 Generated with [Claude Code](https://claude.ai/code)