### PR TITLE
[COMPLETED] Compare Unsafe.SizeOf() method (with inlining) and Size field performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/90
+Your prepared branch: issue-90-5c6486ed
+Your prepared working directory: /tmp/gh-issue-solver-1757831741575
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/90
-Your prepared branch: issue-90-5c6486ed
-Your prepared working directory: /tmp/gh-issue-solver-1757831741575
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs
+++ b/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Platform.Unsafe;
+using Platform.Data.Doublets.Memory.United;
+using Platform.Data.Doublets.Memory.Split;
+using TLinkAddress = System.UInt64;
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace Platform.Data.Doublets.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks comparing performance of Unsafe.SizeOf() method vs Size field approach.
+    /// This addresses issue #90: Compare Unsafe.SizeOf() method (with inlining) and Size field performance
+    /// </summary>
+    [SimpleJob]
+    [MemoryDiagnoser]
+    [MarkdownExporter]
+    [RPlotExporter]
+    public class SizeOfPerformanceBenchmarks
+    {
+        // Sample structures for testing
+        private struct SimpleStruct
+        {
+            public static readonly int SizeField = System.Runtime.CompilerServices.Unsafe.SizeOf<SimpleStruct>();
+            public TLinkAddress Value1;
+            public TLinkAddress Value2;
+        }
+
+        private struct ComplexStruct
+        {
+            public static readonly int SizeField = System.Runtime.CompilerServices.Unsafe.SizeOf<ComplexStruct>();
+            public TLinkAddress Value1;
+            public TLinkAddress Value2;
+            public TLinkAddress Value3;
+            public TLinkAddress Value4;
+            public TLinkAddress Value5;
+            public TLinkAddress Value6;
+            public TLinkAddress Value7;
+            public TLinkAddress Value8;
+        }
+
+        private const int OperationCount = 1000;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Warmup JIT
+            for (int i = 0; i < 100; i++)
+            {
+                GetSizeViaUnsafeSizeOf<SimpleStruct>();
+                GetSizeViaField<SimpleStruct>();
+                GetSizeViaUnsafeSizeOf<RawLink<TLinkAddress>>();
+                GetRawLinkSizeViaField();
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public int SimpleStruct_UnsafeSizeOf()
+        {
+            int total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaUnsafeSizeOf<SimpleStruct>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public int SimpleStruct_SizeField()
+        {
+            int total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaField<SimpleStruct>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public int ComplexStruct_UnsafeSizeOf()
+        {
+            int total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaUnsafeSizeOf<ComplexStruct>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public int ComplexStruct_SizeField()
+        {
+            int total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaField<ComplexStruct>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLink_UnsafeSizeOf()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaUnsafeSizeOf<RawLink<TLinkAddress>>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLink_SizeField()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetRawLinkSizeViaField();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLink_PlatformUnsafeSize()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetRawLinkSizeViaPlatformUnsafe();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLinkDataPart_UnsafeSizeOf()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetSizeViaUnsafeSizeOf<RawLinkDataPart<TLinkAddress>>();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLinkDataPart_SizeField()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetRawLinkDataPartSizeViaField();
+            }
+            return total;
+        }
+
+        [Benchmark]
+        public long RawLinkDataPart_PlatformUnsafeSize()
+        {
+            long total = 0;
+            for (int i = 0; i < OperationCount; i++)
+            {
+                total += GetRawLinkDataPartSizeViaPlatformUnsafe();
+            }
+            return total;
+        }
+
+        // Individual size retrieval methods with aggressive inlining
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetSizeViaUnsafeSizeOf<T>() where T : struct
+        {
+            return System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetSizeViaField<T>() where T : struct
+        {
+            if (typeof(T) == typeof(SimpleStruct))
+            {
+                return SimpleStruct.SizeField;
+            }
+            if (typeof(T) == typeof(ComplexStruct))
+            {
+                return ComplexStruct.SizeField;
+            }
+            throw new NotSupportedException($"Type {typeof(T)} not supported");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long GetRawLinkSizeViaField()
+        {
+            return RawLink<TLinkAddress>.SizeInBytes;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long GetRawLinkSizeViaPlatformUnsafe()
+        {
+            return Structure<RawLink<TLinkAddress>>.Size;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long GetRawLinkDataPartSizeViaField()
+        {
+            return RawLinkDataPart<TLinkAddress>.SizeInBytes;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long GetRawLinkDataPartSizeViaPlatformUnsafe()
+        {
+            return Structure<RawLinkDataPart<TLinkAddress>>.Size;
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Benchmarks/benchmark_results.txt
+++ b/csharp/Platform.Data.Doublets.Benchmarks/benchmark_results.txt
@@ -1,0 +1,2915 @@
+/home/hive/.nuget/packages/microsoft.build.tasks.git/1.1.1/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Could not find file '/tmp/gh-issue-solver-1757831741575/rust/.git'. The source code won't be available via Source Link. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinks.cs(14,24): warning CS1584: XML comment has syntactically incorrect cref attribute 'ILinks{TLinkAddress, LinksConstants{TLinkAddress}}' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinks.cs(14,45): warning CS1658: Type parameter declaration must be an identifier not a type. See also error CS0081. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ISynchronizedLinks.cs(13,24): warning CS1584: XML comment has syntactically incorrect cref attribute 'ISynchronizedLinks{TLinkAddress, ILinks{TLinkAddress}, LinksConstants{TLinkAddress}}' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ISynchronizedLinks.cs(13,57): warning CS1658: Type parameter declaration must be an identifier not a type. See also error CS0081. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ISynchronizedLinks.cs(13,79): warning CS1658: Type parameter declaration must be an identifier not a type. See also error CS0081. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/LinksHeader.cs(100,30): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Doublet.cs(112,30): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(232,30): warning CS8765: Nullability of type of parameter 'other' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/RawLinkDataPart.cs(58,26): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/RawLinkIndexPart.cs(100,26): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(232,34): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/RawLink.cs(100,30): warning CS8765: Nullability of type of parameter 'obj' doesn't match overridden member (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(47,15): warning CS8618: Non-nullable field '_facade' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(500,16): warning CS8618: Non-nullable field '_currentTransactionTransitions' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(500,16): warning CS8618: Non-nullable field '_currentTransaction' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(549,71): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(267,13): warning CS8604: Possible null reference argument for parameter 'collection' in 'bool ICollectionExtensions.IsNullOrEmpty<TLinkAddress>(ICollection<TLinkAddress> collection)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(267,51): warning CS8604: Possible null reference argument for parameter 'collection' in 'bool ICollectionExtensions.IsNullOrEmpty<TLinkAddress>(ICollection<TLinkAddress> collection)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(271,47): warning CS8604: Possible null reference argument for parameter 'right' in 'bool IListExtensions.EqualTo<TLinkAddress>(IList<TLinkAddress> left, IList<TLinkAddress> right)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(285,17): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(302,43): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(317,47): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(331,17): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(352,43): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(620,97): warning CS8604: Possible null reference argument for parameter 'before' in 'Transition.Transition(UniqueTimestampFactory uniqueTimestampFactory, ulong transactionId, IList<ulong> before, IList<ulong> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(620,105): warning CS8604: Possible null reference argument for parameter 'after' in 'Transition.Transition(UniqueTimestampFactory uniqueTimestampFactory, ulong transactionId, IList<ulong> before, IList<ulong> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(656,46): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(657,35): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(704,42): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(159,25): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(160,26): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(161,26): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(174,30): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(178,30): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(179,30): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(182,29): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(183,30): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(184,30): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(206,38): warning CS8600: Converting null literal or possible null value to non-nullable type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(213,29): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(220,20): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(322,31): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(377,31): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(391,178): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(400,171): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(409,179): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(418,171): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(427,179): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(487,24): warning CS8622: Nullability of reference types in type of parameter 'elements' of 'TLinkAddress ListFiller<TLinkAddress, TLinkAddress>.AddFirstAndReturnConstant(IList<TLinkAddress> elements)' doesn't match the target delegate 'ReadHandler<TLinkAddress>' (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(529,33): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(91,31): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(92,29): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(102,21): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(598,33): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(630,33): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(25,41): warning CS8604: Possible null reference argument for parameter 'before' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(25,56): warning CS8604: Possible null reference argument for parameter 'after' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(36,41): warning CS8604: Possible null reference argument for parameter 'before' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(36,56): warning CS8604: Possible null reference argument for parameter 'after' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(47,41): warning CS8604: Possible null reference argument for parameter 'before' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(47,56): warning CS8604: Possible null reference argument for parameter 'after' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(747,102): warning CS8631: The type 'TLinkAddress?' cannot be used as type parameter 'TOther' in the generic type or method 'ulong.CreateTruncating<TOther>(TOther)'. Nullability of type argument 'TLinkAddress?' doesn't match constraint type 'System.Numerics.INumberBase<TLinkAddress?>'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksItselfConstantToSelfReferenceResolver.cs(56,49): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(809,100): warning CS8604: Possible null reference argument for parameter 'defaultValue' in 'Setter<TLinkAddress, TLinkAddress>.Setter(TLinkAddress trueValue, TLinkAddress falseValue, TLinkAddress defaultValue)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(828,33): warning CS8600: Converting null literal or possible null value to non-nullable type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(835,32): warning CS8631: The type 'TLinkAddress?' cannot be used as type parameter 'TLinkAddress' in the generic type or method 'ILinksExtensions.Update<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)'. Nullability of type argument 'TLinkAddress?' doesn't match constraint type 'System.Numerics.IUnsignedNumber<TLinkAddress?>'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(835,32): warning CS8620: Argument of type 'ILinks<TLinkAddress>' cannot be used for parameter 'links' of type 'ILinks<TLinkAddress?>' in 'TLinkAddress? ILinksExtensions.Update<TLinkAddress?>(ILinks<TLinkAddress?> links, TLinkAddress? link, TLinkAddress? newSource, TLinkAddress? newTarget, WriteHandler<TLinkAddress?>? handler)' due to differences in the nullability of reference types. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(835,63): warning CS8622: Nullability of reference types in type of parameter 'before' of 'TLinkAddress HandlerWrapper(IList<TLinkAddress>? before, IList<TLinkAddress>? after)' doesn't match the target delegate 'WriteHandler<TLinkAddress?>' (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(835,63): warning CS8622: Nullability of reference types in type of parameter 'after' of 'TLinkAddress HandlerWrapper(IList<TLinkAddress>? before, IList<TLinkAddress>? after)' doesn't match the target delegate 'WriteHandler<TLinkAddress?>' (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(835,32): warning CS8604: Possible null reference argument for parameter 'result' in 'void WriteHandlerState<TLinkAddress>.Apply(TLinkAddress result)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(832,44): warning CS8604: Possible null reference argument for parameter 'before' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(832,52): warning CS8604: Possible null reference argument for parameter 'after' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(853,40): warning CS8600: Converting null literal or possible null value to non-nullable type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(858,44): warning CS8604: Possible null reference argument for parameter 'before' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(858,52): warning CS8604: Possible null reference argument for parameter 'after' in 'TLinkAddress WriteHandlerState<TLinkAddress>.Handle(IList<TLinkAddress> before, IList<TLinkAddress> after)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(860,32): warning CS8631: The type 'TLinkAddress?' cannot be used as type parameter 'TLinkAddress' in the generic type or method 'ILinksExtensions.Update<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)'. Nullability of type argument 'TLinkAddress?' doesn't match constraint type 'System.Numerics.IUnsignedNumber<TLinkAddress?>'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(860,32): warning CS8620: Argument of type 'ILinks<TLinkAddress>' cannot be used for parameter 'links' of type 'ILinks<TLinkAddress?>' in 'TLinkAddress? ILinksExtensions.Update<TLinkAddress?>(ILinks<TLinkAddress?> links, TLinkAddress? link, TLinkAddress? newSource, TLinkAddress? newTarget, WriteHandler<TLinkAddress?>? handler)' due to differences in the nullability of reference types. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(860,74): warning CS8620: Argument of type 'WriteHandler<TLinkAddress>' cannot be used for parameter 'handler' of type 'WriteHandler<TLinkAddress?>' in 'TLinkAddress? ILinksExtensions.Update<TLinkAddress?>(ILinks<TLinkAddress?> links, TLinkAddress? link, TLinkAddress? newSource, TLinkAddress? newTarget, WriteHandler<TLinkAddress?>? handler)' due to differences in the nullability of reference types. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(860,32): warning CS8604: Possible null reference argument for parameter 'result' in 'void WriteHandlerState<TLinkAddress>.Apply(TLinkAddress result)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(899,20): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs(25,33): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs(40,43): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1021,20): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1030,33): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1085,24): warning CS8622: Nullability of reference types in type of parameter 'elements' of 'TLinkAddress ListFiller<TLinkAddress, TLinkAddress>.AddFirstAndReturnConstant(IList<TLinkAddress> elements)' doesn't match the target delegate 'ReadHandler<TLinkAddress>' (possibly because of nullability attributes). [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1120,33): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Tests/ILinksExtensions.cs(136,25): warning CS8604: Possible null reference argument for parameter 'value' in 'T IIncrementOperators<T>.operator ++(T value)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertyOperator.cs(74,24): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertyOperator.cs(93,20): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertyOperator.cs(96,73): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(59,24): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(67,24): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(136,19): warning CS8618: Non-nullable field 'TargetsTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(136,19): warning CS8618: Non-nullable field 'SourcesTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(136,19): warning CS8618: Non-nullable field 'UnusedLinksListMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'ExternalSourcesTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'ExternalTargetsTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'InternalSourcesListMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'InternalSourcesTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'InternalTargetsTreeMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(168,15): warning CS8618: Non-nullable field 'UnusedLinksListMethods' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksAvlBalancedTreeMethodsBase.cs(252,22): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(211,17): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(308,58): warning CS8604: Possible null reference argument for parameter 'second' in 'bool UnitedMemoryLinksBase<TLinkAddress>.AreEqual(TLinkAddress first, TLinkAddress second)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksRecursionlessSizeBalancedTreeMethodsBase.cs(448,18): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(246,13): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(345,17): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(349,50): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(369,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(394,32): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(400,32): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(426,77): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(437,32): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(445,36): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(458,58): warning CS8604: Possible null reference argument for parameter 'second' in 'bool UnitedMemoryLinksBase<TLinkAddress>.AreEqual(TLinkAddress first, TLinkAddress second)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(461,32): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSizeBalancedTreeMethodsBase.cs(448,18): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(551,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(616,34): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(617,34): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(618,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(691,52): warning CS8604: Possible null reference argument for parameter 'second' in 'bool UnitedMemoryLinksBase<TLinkAddress>.AreEqual(TLinkAddress first, TLinkAddress second)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(691,87): warning CS8604: Possible null reference argument for parameter 'second' in 'bool UnitedMemoryLinksBase<TLinkAddress>.AreEqual(TLinkAddress first, TLinkAddress second)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(723,53): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(438,13): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(442,44): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(462,20): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(485,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(490,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(571,63): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(579,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(586,28): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(601,24): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(28,54): warning CS8601: Possible null reference assignment. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(29,55): warning CS8604: Possible null reference argument for parameter 'value' in 'TLinkAddress IIncrementOperators<TLinkAddress>.operator ++(TLinkAddress value)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(480,18): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(738,20): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSizeBalancedTreeMethodsBase.cs(480,18): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(873,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(874,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(875,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(876,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(877,38): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(878,34): warning CS8625: Cannot convert null literal to non-nullable reference type. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(1004,16): warning CS8603: Possible null reference return. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(28,51): warning CS8604: Possible null reference argument for parameter 'value' in 'TLinkAddress IIncrementOperators<TLinkAddress>.operator ++(TLinkAddress value)'. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSizeBalancedTreeMethodsBase.cs(397,14): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSourcesLinkedListMethods.cs(387,18): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(397,14): warning CS8602: Dereference of a possibly null reference. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/CriterionMatchers/TargetMatcher.cs(24,46): warning CS1574: XML comment has cref attribute 'TargetMatcher' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksCascadeUniquenessAndUsagesResolver.cs(20,46): warning CS1574: XML comment has cref attribute 'LinksCascadeUniquenessAndUsagesResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksCascadeUniquenessAndUsagesResolver.cs(50,152): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksCascadeUniquenessAndUsagesResolver<TLinkAddress>.ResolveAddressChangeConflict(TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksCascadeUsagesResolver.cs(18,46): warning CS1574: XML comment has cref attribute 'LinksCascadeUsagesResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksCascadeUsagesResolver.cs(40,103): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksCascadeUsagesResolver<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(38,46): warning CS1574: XML comment has cref attribute 'LinksDecoratorBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(136,22): warning CS1572: XML comment has a param tag for 'restriction', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(145,61): warning CS1573: Parameter 'substitution' has no matching param tag in the XML comment for 'LinksDecoratorBase<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(145,103): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksDecoratorBase<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(169,137): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksDecoratorBase<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDecoratorBase.cs(185,102): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksDecoratorBase<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksDisposableDecoratorBase.cs(32,46): warning CS1574: XML comment has cref attribute 'LinksDisposableDecoratorBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksInnerReferenceExistenceValidator.cs(22,46): warning CS1574: XML comment has cref attribute 'LinksInnerReferenceExistenceValidator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksInnerReferenceExistenceValidator.cs(78,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksInnerReferenceExistenceValidator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksInnerReferenceExistenceValidator.cs(98,103): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksInnerReferenceExistenceValidator<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksItselfConstantToSelfReferenceResolver.cs(22,46): warning CS1574: XML comment has cref attribute 'LinksItselfConstantToSelfReferenceResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksItselfConstantToSelfReferenceResolver.cs(83,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksItselfConstantToSelfReferenceResolver<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksNonExistentDependenciesCreator.cs(21,46): warning CS1574: XML comment has cref attribute 'LinksNonExistentDependenciesCreator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksNonExistentDependenciesCreator.cs(51,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksNonExistentDependenciesCreator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksNullConstantToSelfReferenceResolver.cs(21,46): warning CS1574: XML comment has cref attribute 'LinksNullConstantToSelfReferenceResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksNullConstantToSelfReferenceResolver.cs(47,104): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksNullConstantToSelfReferenceResolver<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksNullConstantToSelfReferenceResolver.cs(71,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksNullConstantToSelfReferenceResolver<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUniquenessResolver.cs(22,46): warning CS1574: XML comment has cref attribute 'LinksUniquenessResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUniquenessResolver.cs(52,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksUniquenessResolver<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUniquenessResolver.cs(83,151): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksUniquenessResolver<TLinkAddress>.ResolveAddressChangeConflict(TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUniquenessValidator.cs(21,46): warning CS1574: XML comment has cref attribute 'LinksUniquenessValidator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUniquenessValidator.cs(51,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksUniquenessValidator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUsagesValidator.cs(21,46): warning CS1574: XML comment has cref attribute 'LinksUsagesValidator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUsagesValidator.cs(51,138): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksUsagesValidator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LinksUsagesValidator.cs(69,103): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'LinksUsagesValidator<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(8,14): warning CS1591: Missing XML comment for publicly visible type or member 'LoggingDecorator<TLinkAddress>' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(13,12): warning CS1591: Missing XML comment for publicly visible type or member 'LoggingDecorator<TLinkAddress>.LoggingDecorator(ILinks<TLinkAddress>, Stream)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(20,34): warning CS1591: Missing XML comment for publicly visible type or member 'LoggingDecorator<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(31,34): warning CS1591: Missing XML comment for publicly visible type or member 'LoggingDecorator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/LoggingDecorator.cs(42,34): warning CS1591: Missing XML comment for publicly visible type or member 'LoggingDecorator<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(9,14): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(11,12): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.NoExceptionsDecorator(ILinks<TLinkAddress>)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(13,34): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.Count(IList<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(26,34): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.Each(IList<TLinkAddress>?, ReadHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(39,34): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(52,34): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NoExceptionsDecorator.cs(65,34): warning CS1591: Missing XML comment for publicly visible type or member 'NoExceptionsDecorator<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NonNullContentsLinkDeletionResolver.cs(21,46): warning CS1574: XML comment has cref attribute 'NonNullContentsLinkDeletionResolver' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/NonNullContentsLinkDeletionResolver.cs(43,103): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'NonNullContentsLinkDeletionResolver<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(35,42): warning CS1574: XML comment has cref attribute 'UInt64Links' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(61,108): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'CombinedDecorator<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(82,142): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'CombinedDecorator<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UInt64Links.cs(127,107): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'CombinedDecorator<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Decorators/UniLinks.cs(25,46): warning CS1574: XML comment has cref attribute 'UniLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Doublet.cs(26,30): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Doublet.cs(36,30): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Doublet.cs(46,30): warning CS1711: XML comment has a typeparam tag for 'T', but there is no type parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(148,145): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.Delete<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(711,108): warning CS1573: Parameter 'source' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureDoesNotExists<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(711,129): warning CS1573: Parameter 'target' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureDoesNotExists<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(721,103): warning CS1573: Parameter 'link' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureNoUsages<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(731,111): warning CS1573: Parameter 'addresses' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureCreated<TLinkAddress>(ILinks<TLinkAddress>, params TLinkAddress[])' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(735,117): warning CS1573: Parameter 'addresses' has no matching param tag in the XML comment for 'ILinksExtensions.EnsurePointsCreated<TLinkAddress>(ILinks<TLinkAddress>, params TLinkAddress[])' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(739,108): warning CS1573: Parameter 'creator' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureCreated<TLinkAddress>(ILinks<TLinkAddress>, Func<TLinkAddress>, params TLinkAddress[])' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(739,139): warning CS1573: Parameter 'addresses' has no matching param tag in the XML comment for 'ILinksExtensions.EnsureCreated<TLinkAddress>(ILinks<TLinkAddress>, Func<TLinkAddress>, params TLinkAddress[])' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(768,108): warning CS1573: Parameter 'link' has no matching param tag in the XML comment for 'ILinksExtensions.CountUsages<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(787,98): warning CS1573: Parameter 'link' has no matching param tag in the XML comment for 'ILinksExtensions.HasUsages<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(791,95): warning CS1573: Parameter 'link' has no matching param tag in the XML comment for 'ILinksExtensions.Equals<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(791,114): warning CS1573: Parameter 'source' has no matching param tag in the XML comment for 'ILinksExtensions.Equals<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(791,135): warning CS1573: Parameter 'target' has no matching param tag in the XML comment for 'ILinksExtensions.Equals<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(824,123): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.CreatePoint<TLinkAddress>(ILinks<TLinkAddress>, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(850,112): warning CS1573: Parameter 'source' has no matching param tag in the XML comment for 'ILinksExtensions.CreateAndUpdate<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(850,133): warning CS1573: Parameter 'target' has no matching param tag in the XML comment for 'ILinksExtensions.CreateAndUpdate<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(850,169): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.CreateAndUpdate<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(897,152): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.Update<TLinkAddress>(ILinks<TLinkAddress>, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(993,221): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.UpdateOrCreateOrGet<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, TLinkAddress, TLinkAddress, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1152,147): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.ResetValues<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/ILinksExtensions.cs(1182,154): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'ILinksExtensions.EnforceResetValues<TLinkAddress>(ILinks<TLinkAddress>, TLinkAddress, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(54,42): warning CS1574: XML comment has cref attribute 'Link' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(67,42): warning CS1574: XML comment has cref attribute 'Link' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(80,42): warning CS1574: XML comment has cref attribute 'Link' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(111,42): warning CS1574: XML comment has cref attribute 'Link' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Link.cs(124,42): warning CS1574: XML comment has cref attribute 'Link' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/LinksOperatorBase.cs(38,42): warning CS1574: XML comment has cref attribute 'LinksOperatorBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(63,46): warning CS1574: XML comment has cref attribute 'ExternalLinksRecursionlessSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(218,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(231,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'ExternalLinksRecursionlessSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSizeBalancedTreeMethodsBase.cs(63,46): warning CS1574: XML comment has cref attribute 'ExternalLinksSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSizeBalancedTreeMethodsBase.cs(218,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSizeBalancedTreeMethodsBase.cs(231,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'ExternalLinksSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSourcesRecursionlessSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'ExternalLinksSourcesRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksSourcesSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'ExternalLinksSourcesSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksTargetsRecursionlessSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'ExternalLinksTargetsRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/ExternalLinksTargetsSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'ExternalLinksTargetsSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(63,46): warning CS1574: XML comment has cref attribute 'InternalLinksRecursionlessSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(165,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksRecursionlessSizeBalancedTreeMethodsBase.cs(178,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'InternalLinksRecursionlessSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSizeBalancedTreeMethodsBase.cs(63,46): warning CS1574: XML comment has cref attribute 'InternalLinksSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSizeBalancedTreeMethodsBase.cs(165,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSizeBalancedTreeMethodsBase.cs(178,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'InternalLinksSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSourcesLinkedListMethods.cs(41,46): warning CS1574: XML comment has cref attribute 'InternalLinksSourcesLinkedListMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSourcesRecursionlessSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'InternalLinksSourcesRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksSourcesSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'InternalLinksSourcesSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksTargetsRecursionlessSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'InternalLinksTargetsRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/InternalLinksTargetsSizeBalancedTreeMethods.cs(19,46): warning CS1574: XML comment has cref attribute 'InternalLinksTargetsSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs(31,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs(48,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs(65,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs(86,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinks.cs(111,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(143,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinksBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(180,46): warning CS1574: XML comment has cref attribute 'SplitMemoryLinksBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/SplitMemoryLinksBase.cs(735,102): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'SplitMemoryLinksBase<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/Split/Generic/UnusedLinksListMethods.cs(26,46): warning CS1574: XML comment has cref attribute 'UnusedLinksListMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksAvlBalancedTreeMethodsBase.cs(60,46): warning CS1574: XML comment has cref attribute 'LinksAvlBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksRecursionlessSizeBalancedTreeMethodsBase.cs(56,46): warning CS1574: XML comment has cref attribute 'LinksRecursionlessSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksRecursionlessSizeBalancedTreeMethodsBase.cs(206,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksRecursionlessSizeBalancedTreeMethodsBase.cs(219,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'LinksRecursionlessSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSizeBalancedTreeMethodsBase.cs(56,46): warning CS1574: XML comment has cref attribute 'LinksSizeBalancedTreeMethodsBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSizeBalancedTreeMethodsBase.cs(206,22): warning CS1572: XML comment has a param tag for '@base', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSizeBalancedTreeMethodsBase.cs(219,48): warning CS1573: Parameter 'base' has no matching param tag in the XML comment for 'LinksSizeBalancedTreeMethodsBase<TLinkAddress>.EachUsage(TLinkAddress, ReadHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSourcesAvlBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksSourcesAvlBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSourcesRecursionlessSizeBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksSourcesRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSourcesSizeBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksSourcesSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksTargetsAvlBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksTargetsAvlBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksTargetsRecursionlessSizeBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksTargetsRecursionlessSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksTargetsSizeBalancedTreeMethods.cs(19,42): warning CS1574: XML comment has cref attribute 'LinksTargetsSizeBalancedTreeMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs(28,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs(49,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs(62,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinks.cs(79,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(119,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinksBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(145,42): warning CS1574: XML comment has cref attribute 'UnitedMemoryLinksBase' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnitedMemoryLinksBase.cs(548,106): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'UnitedMemoryLinksBase<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Memory/United/Generic/UnusedLinksListMethods.cs(26,42): warning CS1574: XML comment has cref attribute 'UnusedLinksListMethods' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(23,42): warning CS1574: XML comment has cref attribute 'PropertiesOperator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(40,26): warning CS1572: XML comment has a param tag for '@object', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(53,51): warning CS1573: Parameter 'object' has no matching param tag in the XML comment for 'PropertiesOperator<TLinkAddress>.GetValue(TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(78,26): warning CS1572: XML comment has a param tag for '@object', but there is no parameter by that name [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertiesOperator.cs(91,43): warning CS1573: Parameter 'object' has no matching param tag in the XML comment for 'PropertiesOperator<TLinkAddress>.SetValue(TLinkAddress, TLinkAddress, TLinkAddress)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/PropertyOperators/PropertyOperator.cs(25,42): warning CS1574: XML comment has cref attribute 'PropertyOperator' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/SynchronizedLinks.cs(70,42): warning CS1574: XML comment has cref attribute 'SynchronizedLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/SynchronizedLinks.cs(83,42): warning CS1574: XML comment has cref attribute 'SynchronizedLinks' that could not be resolved [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/SynchronizedLinks.cs(157,99): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'SynchronizedLinks<TLinkAddress>.Create(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/SynchronizedLinks.cs(178,133): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'SynchronizedLinks<TLinkAddress>.Update(IList<TLinkAddress>?, IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/SynchronizedLinks.cs(191,98): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'SynchronizedLinks<TLinkAddress>.Delete(IList<TLinkAddress>?, WriteHandler<TLinkAddress>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(566,108): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'UInt64LinksTransactionsLayer.Create(IList<ulong>?, WriteHandler<ulong>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(594,142): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'UInt64LinksTransactionsLayer.Update(IList<ulong>?, IList<ulong>?, WriteHandler<ulong>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/UInt64LinksTransactionsLayer.cs(615,107): warning CS1573: Parameter 'handler' has no matching param tag in the XML comment for 'UInt64LinksTransactionsLayer.Delete(IList<ulong>?, WriteHandler<ulong>?)' (but other parameters do) [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/CountBenchmarks.cs(18,45): warning CS8618: Non-nullable field '_links' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/CountBenchmarks.cs(21,50): warning CS8618: Non-nullable field '_dataMemory' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(38,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value5' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(28,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.SimpleStruct.Value2' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(37,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value4' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(40,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value7' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(41,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value8' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(35,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value2' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(34,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value1' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(27,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.SimpleStruct.Value1' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(39,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value6' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs(36,33): warning CS0649: Field 'SizeOfPerformanceBenchmarks.ComplexStruct.Value3' is never assigned to, and will always have its default value 0 [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/Platform.Data.Doublets.Benchmarks.csproj]
+// Validating benchmarks:
+Assembly Platform.Data.Doublets.Benchmarks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null is located in temp. If you are running benchmarks from xUnit you need to disable shadow copy. It's not supported by design.
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 15 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet restore  /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe
+// command took 17.36s and exited with 0
+// start dotnet build -c Release  --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe
+// command took 35.68s and exited with 0
+// ***** Done, took 00:00:54 (54.02 sec)   *****
+// Found 15 benchmarks:
+//   CountBenchmarks.Array: DefaultJob [N=10]
+//   CountBenchmarks.List: DefaultJob [N=10]
+//   CountBenchmarks.ListWithCapacity: DefaultJob [N=10]
+//   CountBenchmarks.Array: DefaultJob [N=100]
+//   CountBenchmarks.List: DefaultJob [N=100]
+//   CountBenchmarks.ListWithCapacity: DefaultJob [N=100]
+//   CountBenchmarks.Array: DefaultJob [N=1000]
+//   CountBenchmarks.List: DefaultJob [N=1000]
+//   CountBenchmarks.ListWithCapacity: DefaultJob [N=1000]
+//   CountBenchmarks.Array: DefaultJob [N=10000]
+//   CountBenchmarks.List: DefaultJob [N=10000]
+//   CountBenchmarks.ListWithCapacity: DefaultJob [N=10000]
+//   CountBenchmarks.Array: DefaultJob [N=100000]
+//   CountBenchmarks.List: DefaultJob [N=100000]
+//   CountBenchmarks.ListWithCapacity: DefaultJob [N=100000]
+
+// **************************
+// Benchmark: CountBenchmarks.Array: DefaultJob [N=10]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.Array(N: 10)" --job "Default" --benchmarkId 0 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 896080.00 ns, 896.0800 us/op
+WorkloadJitting  1: 1 op, 15247224.00 ns, 15.2472 ms/op
+
+OverheadJitting  2: 16 op, 2163175.00 ns, 135.1984 us/op
+WorkloadJitting  2: 16 op, 1319017.00 ns, 82.4386 us/op
+
+WorkloadPilot    1: 16 op, 1339698.00 ns, 83.7311 us/op
+WorkloadPilot    2: 32 op, 593689.00 ns, 18.5528 us/op
+WorkloadPilot    3: 64 op, 3424962.00 ns, 53.5150 us/op
+WorkloadPilot    4: 128 op, 4419608.00 ns, 34.5282 us/op
+WorkloadPilot    5: 256 op, 10811406.00 ns, 42.2321 us/op
+WorkloadPilot    6: 512 op, 16960098.00 ns, 33.1252 us/op
+WorkloadPilot    7: 1024 op, 40334913.00 ns, 39.3896 us/op
+WorkloadPilot    8: 2048 op, 62598246.00 ns, 30.5655 us/op
+WorkloadPilot    9: 4096 op, 132055945.00 ns, 32.2402 us/op
+WorkloadPilot   10: 8192 op, 257298873.00 ns, 31.4086 us/op
+WorkloadPilot   11: 16384 op, 493066430.00 ns, 30.0944 us/op
+WorkloadPilot   12: 32768 op, 1071118392.00 ns, 32.6879 us/op
+
+OverheadWarmup   1: 32768 op, 2358765.00 ns, 71.9838 ns/op
+OverheadWarmup   2: 32768 op, 2276944.00 ns, 69.4868 ns/op
+OverheadWarmup   3: 32768 op, 2286613.00 ns, 69.7819 ns/op
+OverheadWarmup   4: 32768 op, 4427068.00 ns, 135.1034 ns/op
+OverheadWarmup   5: 32768 op, 13856436.00 ns, 422.8649 ns/op
+OverheadWarmup   6: 32768 op, 801407.00 ns, 24.4570 ns/op
+OverheadWarmup   7: 32768 op, 771692.00 ns, 23.5502 ns/op
+OverheadWarmup   8: 32768 op, 960490.00 ns, 29.3118 ns/op
+OverheadWarmup   9: 32768 op, 662069.00 ns, 20.2047 ns/op
+
+OverheadActual   1: 32768 op, 858735.00 ns, 26.2065 ns/op
+OverheadActual   2: 32768 op, 679144.00 ns, 20.7258 ns/op
+OverheadActual   3: 32768 op, 867814.00 ns, 26.4836 ns/op
+OverheadActual   4: 32768 op, 839643.00 ns, 25.6239 ns/op
+OverheadActual   5: 32768 op, 1894509.00 ns, 57.8158 ns/op
+OverheadActual   6: 32768 op, 1853830.00 ns, 56.5744 ns/op
+OverheadActual   7: 32768 op, 1761771.00 ns, 53.7650 ns/op
+OverheadActual   8: 32768 op, 705047.00 ns, 21.5163 ns/op
+OverheadActual   9: 32768 op, 764667.00 ns, 23.3358 ns/op
+OverheadActual  10: 32768 op, 2082808.00 ns, 63.5623 ns/op
+OverheadActual  11: 32768 op, 1321494.00 ns, 40.3288 ns/op
+OverheadActual  12: 32768 op, 653989.00 ns, 19.9582 ns/op
+OverheadActual  13: 32768 op, 1784676.00 ns, 54.4640 ns/op
+OverheadActual  14: 32768 op, 2004791.00 ns, 61.1814 ns/op
+OverheadActual  15: 32768 op, 835478.00 ns, 25.4968 ns/op
+OverheadActual  16: 32768 op, 729823.00 ns, 22.2724 ns/op
+OverheadActual  17: 32768 op, 3075070.00 ns, 93.8437 ns/op
+OverheadActual  18: 32768 op, 1895181.00 ns, 57.8363 ns/op
+OverheadActual  19: 32768 op, 683871.00 ns, 20.8701 ns/op
+OverheadActual  20: 32768 op, 2847705.00 ns, 86.9051 ns/op
+
+WorkloadWarmup   1: 32768 op, 244824266.00 ns, 7.4714 us/op
+WorkloadWarmup   2: 32768 op, 216871172.00 ns, 6.6184 us/op
+WorkloadWarmup   3: 32768 op, 226868805.00 ns, 6.9235 us/op
+WorkloadWarmup   4: 32768 op, 166374373.00 ns, 5.0773 us/op
+WorkloadWarmup   5: 32768 op, 158560452.00 ns, 4.8389 us/op
+WorkloadWarmup   6: 32768 op, 160899155.00 ns, 4.9103 us/op
+WorkloadWarmup   7: 32768 op, 167900703.00 ns, 5.1239 us/op
+WorkloadWarmup   8: 32768 op, 149914965.00 ns, 4.5750 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 32768 op, 174646921.00 ns, 5.3298 us/op
+WorkloadActual   2: 32768 op, 143761228.00 ns, 4.3872 us/op
+WorkloadActual   3: 32768 op, 149020064.00 ns, 4.5477 us/op
+WorkloadActual   4: 32768 op, 150299503.00 ns, 4.5868 us/op
+WorkloadActual   5: 32768 op, 154833269.00 ns, 4.7251 us/op
+WorkloadActual   6: 32768 op, 177620962.00 ns, 5.4206 us/op
+WorkloadActual   7: 32768 op, 147060650.00 ns, 4.4879 us/op
+WorkloadActual   8: 32768 op, 145175102.00 ns, 4.4304 us/op
+WorkloadActual   9: 32768 op, 166584010.00 ns, 5.0837 us/op
+WorkloadActual  10: 32768 op, 149084380.00 ns, 4.5497 us/op
+WorkloadActual  11: 32768 op, 159347815.00 ns, 4.8629 us/op
+WorkloadActual  12: 32768 op, 157591231.00 ns, 4.8093 us/op
+WorkloadActual  13: 32768 op, 212265856.00 ns, 6.4778 us/op
+WorkloadActual  14: 32768 op, 129854605.00 ns, 3.9628 us/op
+WorkloadActual  15: 32768 op, 158389298.00 ns, 4.8337 us/op
+WorkloadActual  16: 32768 op, 152187852.00 ns, 4.6444 us/op
+WorkloadActual  17: 32768 op, 115713627.00 ns, 3.5313 us/op
+WorkloadActual  18: 32768 op, 198770349.00 ns, 6.0660 us/op
+WorkloadActual  19: 32768 op, 121318950.00 ns, 3.7024 us/op
+WorkloadActual  20: 32768 op, 157413914.00 ns, 4.8039 us/op
+WorkloadActual  21: 32768 op, 150160632.00 ns, 4.5825 us/op
+WorkloadActual  22: 32768 op, 173151227.00 ns, 5.2842 us/op
+WorkloadActual  23: 32768 op, 159587535.00 ns, 4.8702 us/op
+WorkloadActual  24: 32768 op, 146899814.00 ns, 4.4830 us/op
+WorkloadActual  25: 32768 op, 155178419.00 ns, 4.7357 us/op
+WorkloadActual  26: 32768 op, 126203060.00 ns, 3.8514 us/op
+WorkloadActual  27: 32768 op, 116272065.00 ns, 3.5483 us/op
+WorkloadActual  28: 32768 op, 130660091.00 ns, 3.9874 us/op
+WorkloadActual  29: 32768 op, 119223734.00 ns, 3.6384 us/op
+WorkloadActual  30: 32768 op, 121319456.00 ns, 3.7024 us/op
+WorkloadActual  31: 32768 op, 116624490.00 ns, 3.5591 us/op
+WorkloadActual  32: 32768 op, 119881798.00 ns, 3.6585 us/op
+WorkloadActual  33: 32768 op, 120612142.00 ns, 3.6808 us/op
+WorkloadActual  34: 32768 op, 184818006.00 ns, 5.6402 us/op
+WorkloadActual  35: 32768 op, 210718683.00 ns, 6.4306 us/op
+WorkloadActual  36: 32768 op, 175720081.00 ns, 5.3626 us/op
+WorkloadActual  37: 32768 op, 141496415.00 ns, 4.3181 us/op
+WorkloadActual  38: 32768 op, 137444818.00 ns, 4.1945 us/op
+WorkloadActual  39: 32768 op, 121348970.00 ns, 3.7033 us/op
+WorkloadActual  40: 32768 op, 144121086.00 ns, 4.3982 us/op
+WorkloadActual  41: 32768 op, 130282812.00 ns, 3.9759 us/op
+WorkloadActual  42: 32768 op, 183810566.00 ns, 5.6095 us/op
+WorkloadActual  43: 32768 op, 195542231.00 ns, 5.9675 us/op
+WorkloadActual  44: 32768 op, 137361279.00 ns, 4.1919 us/op
+WorkloadActual  45: 32768 op, 130781838.00 ns, 3.9911 us/op
+WorkloadActual  46: 32768 op, 149209559.00 ns, 4.5535 us/op
+WorkloadActual  47: 32768 op, 183354565.00 ns, 5.5955 us/op
+WorkloadActual  48: 32768 op, 140066888.00 ns, 4.2745 us/op
+WorkloadActual  49: 32768 op, 148675845.00 ns, 4.5372 us/op
+WorkloadActual  50: 32768 op, 154010709.00 ns, 4.7000 us/op
+WorkloadActual  51: 32768 op, 144212782.00 ns, 4.4010 us/op
+WorkloadActual  52: 32768 op, 159700907.00 ns, 4.8737 us/op
+WorkloadActual  53: 32768 op, 145104243.00 ns, 4.4282 us/op
+WorkloadActual  54: 32768 op, 140481460.00 ns, 4.2872 us/op
+WorkloadActual  55: 32768 op, 130578507.00 ns, 3.9849 us/op
+WorkloadActual  56: 32768 op, 134928106.00 ns, 4.1177 us/op
+WorkloadActual  57: 32768 op, 131115692.00 ns, 4.0013 us/op
+WorkloadActual  58: 32768 op, 148461444.00 ns, 4.5307 us/op
+WorkloadActual  59: 32768 op, 173019126.00 ns, 5.2801 us/op
+WorkloadActual  60: 32768 op, 255111676.00 ns, 7.7854 us/op
+WorkloadActual  61: 32768 op, 249305566.00 ns, 7.6082 us/op
+WorkloadActual  62: 32768 op, 226975291.00 ns, 6.9267 us/op
+WorkloadActual  63: 32768 op, 219305553.00 ns, 6.6927 us/op
+WorkloadActual  64: 32768 op, 167581740.00 ns, 5.1142 us/op
+WorkloadActual  65: 32768 op, 238227477.00 ns, 7.2701 us/op
+WorkloadActual  66: 32768 op, 193792585.00 ns, 5.9141 us/op
+WorkloadActual  67: 32768 op, 162999589.00 ns, 4.9744 us/op
+WorkloadActual  68: 32768 op, 246723332.00 ns, 7.5294 us/op
+WorkloadActual  69: 32768 op, 166264425.00 ns, 5.0740 us/op
+WorkloadActual  70: 32768 op, 120300895.00 ns, 3.6713 us/op
+WorkloadActual  71: 32768 op, 163150926.00 ns, 4.9790 us/op
+WorkloadActual  72: 32768 op, 332549153.00 ns, 10.1486 us/op
+WorkloadActual  73: 32768 op, 359111461.00 ns, 10.9592 us/op
+WorkloadActual  74: 32768 op, 221876789.00 ns, 6.7711 us/op
+WorkloadActual  75: 32768 op, 269991901.00 ns, 8.2395 us/op
+WorkloadActual  76: 32768 op, 289076044.00 ns, 8.8219 us/op
+WorkloadActual  77: 32768 op, 240865145.00 ns, 7.3506 us/op
+WorkloadActual  78: 32768 op, 132949763.00 ns, 4.0573 us/op
+WorkloadActual  79: 32768 op, 129309741.00 ns, 3.9462 us/op
+WorkloadActual  80: 32768 op, 118958772.00 ns, 3.6303 us/op
+WorkloadActual  81: 32768 op, 122771581.00 ns, 3.7467 us/op
+WorkloadActual  82: 32768 op, 120181443.00 ns, 3.6676 us/op
+WorkloadActual  83: 32768 op, 199712061.00 ns, 6.0947 us/op
+WorkloadActual  84: 32768 op, 366589790.00 ns, 11.1874 us/op
+WorkloadActual  85: 32768 op, 368883643.00 ns, 11.2574 us/op
+WorkloadActual  86: 32768 op, 307626701.00 ns, 9.3880 us/op
+WorkloadActual  87: 32768 op, 318868266.00 ns, 9.7311 us/op
+WorkloadActual  88: 32768 op, 127192094.00 ns, 3.8816 us/op
+WorkloadActual  89: 32768 op, 132491896.00 ns, 4.0433 us/op
+WorkloadActual  90: 32768 op, 128552546.00 ns, 3.9231 us/op
+WorkloadActual  91: 32768 op, 139183911.00 ns, 4.2476 us/op
+WorkloadActual  92: 32768 op, 117134657.00 ns, 3.5747 us/op
+WorkloadActual  93: 32768 op, 125096295.00 ns, 3.8176 us/op
+WorkloadActual  94: 32768 op, 116454039.00 ns, 3.5539 us/op
+WorkloadActual  95: 32768 op, 120427531.00 ns, 3.6752 us/op
+WorkloadActual  96: 32768 op, 138402305.00 ns, 4.2237 us/op
+WorkloadActual  97: 32768 op, 127318726.00 ns, 3.8855 us/op
+WorkloadActual  98: 32768 op, 157561256.00 ns, 4.8084 us/op
+WorkloadActual  99: 32768 op, 141770395.00 ns, 4.3265 us/op
+WorkloadActual  100: 32768 op, 114343093.00 ns, 3.4895 us/op
+
+// AfterActualRun
+WorkloadResult   1: 32768 op, 173552267.00 ns, 5.2964 us/op
+WorkloadResult   2: 32768 op, 142666574.00 ns, 4.3538 us/op
+WorkloadResult   3: 32768 op, 147925410.00 ns, 4.5143 us/op
+WorkloadResult   4: 32768 op, 149204849.00 ns, 4.5534 us/op
+WorkloadResult   5: 32768 op, 153738615.00 ns, 4.6917 us/op
+WorkloadResult   6: 32768 op, 176526308.00 ns, 5.3872 us/op
+WorkloadResult   7: 32768 op, 145965996.00 ns, 4.4545 us/op
+WorkloadResult   8: 32768 op, 144080448.00 ns, 4.3970 us/op
+WorkloadResult   9: 32768 op, 165489356.00 ns, 5.0503 us/op
+WorkloadResult  10: 32768 op, 147989726.00 ns, 4.5163 us/op
+WorkloadResult  11: 32768 op, 158253161.00 ns, 4.8295 us/op
+WorkloadResult  12: 32768 op, 156496577.00 ns, 4.7759 us/op
+WorkloadResult  13: 32768 op, 211171202.00 ns, 6.4444 us/op
+WorkloadResult  14: 32768 op, 128759951.00 ns, 3.9294 us/op
+WorkloadResult  15: 32768 op, 157294644.00 ns, 4.8003 us/op
+WorkloadResult  16: 32768 op, 151093198.00 ns, 4.6110 us/op
+WorkloadResult  17: 32768 op, 114618973.00 ns, 3.4979 us/op
+WorkloadResult  18: 32768 op, 197675695.00 ns, 6.0326 us/op
+WorkloadResult  19: 32768 op, 120224296.00 ns, 3.6690 us/op
+WorkloadResult  20: 32768 op, 156319260.00 ns, 4.7705 us/op
+WorkloadResult  21: 32768 op, 149065978.00 ns, 4.5491 us/op
+WorkloadResult  22: 32768 op, 172056573.00 ns, 5.2507 us/op
+WorkloadResult  23: 32768 op, 158492881.00 ns, 4.8368 us/op
+WorkloadResult  24: 32768 op, 145805160.00 ns, 4.4496 us/op
+WorkloadResult  25: 32768 op, 154083765.00 ns, 4.7023 us/op
+WorkloadResult  26: 32768 op, 125108406.00 ns, 3.8180 us/op
+WorkloadResult  27: 32768 op, 115177411.00 ns, 3.5149 us/op
+WorkloadResult  28: 32768 op, 129565437.00 ns, 3.9540 us/op
+WorkloadResult  29: 32768 op, 118129080.00 ns, 3.6050 us/op
+WorkloadResult  30: 32768 op, 120224802.00 ns, 3.6690 us/op
+WorkloadResult  31: 32768 op, 115529836.00 ns, 3.5257 us/op
+WorkloadResult  32: 32768 op, 118787144.00 ns, 3.6251 us/op
+WorkloadResult  33: 32768 op, 119517488.00 ns, 3.6474 us/op
+WorkloadResult  34: 32768 op, 183723352.00 ns, 5.6068 us/op
+WorkloadResult  35: 32768 op, 209624029.00 ns, 6.3972 us/op
+WorkloadResult  36: 32768 op, 174625427.00 ns, 5.3291 us/op
+WorkloadResult  37: 32768 op, 140401761.00 ns, 4.2847 us/op
+WorkloadResult  38: 32768 op, 136350164.00 ns, 4.1611 us/op
+WorkloadResult  39: 32768 op, 120254316.00 ns, 3.6699 us/op
+WorkloadResult  40: 32768 op, 143026432.00 ns, 4.3648 us/op
+WorkloadResult  41: 32768 op, 129188158.00 ns, 3.9425 us/op
+WorkloadResult  42: 32768 op, 182715912.00 ns, 5.5760 us/op
+WorkloadResult  43: 32768 op, 194447577.00 ns, 5.9341 us/op
+WorkloadResult  44: 32768 op, 136266625.00 ns, 4.1585 us/op
+WorkloadResult  45: 32768 op, 129687184.00 ns, 3.9577 us/op
+WorkloadResult  46: 32768 op, 148114905.00 ns, 4.5201 us/op
+WorkloadResult  47: 32768 op, 182259911.00 ns, 5.5621 us/op
+WorkloadResult  48: 32768 op, 138972234.00 ns, 4.2411 us/op
+WorkloadResult  49: 32768 op, 147581191.00 ns, 4.5038 us/op
+WorkloadResult  50: 32768 op, 152916055.00 ns, 4.6666 us/op
+WorkloadResult  51: 32768 op, 143118128.00 ns, 4.3676 us/op
+WorkloadResult  52: 32768 op, 158606253.00 ns, 4.8403 us/op
+WorkloadResult  53: 32768 op, 144009589.00 ns, 4.3948 us/op
+WorkloadResult  54: 32768 op, 139386806.00 ns, 4.2537 us/op
+WorkloadResult  55: 32768 op, 129483853.00 ns, 3.9515 us/op
+WorkloadResult  56: 32768 op, 133833452.00 ns, 4.0843 us/op
+WorkloadResult  57: 32768 op, 130021038.00 ns, 3.9679 us/op
+WorkloadResult  58: 32768 op, 147366790.00 ns, 4.4973 us/op
+WorkloadResult  59: 32768 op, 171924472.00 ns, 5.2467 us/op
+WorkloadResult  60: 32768 op, 248210912.00 ns, 7.5748 us/op
+WorkloadResult  61: 32768 op, 225880637.00 ns, 6.8933 us/op
+WorkloadResult  62: 32768 op, 218210899.00 ns, 6.6593 us/op
+WorkloadResult  63: 32768 op, 166487086.00 ns, 5.0808 us/op
+WorkloadResult  64: 32768 op, 237132823.00 ns, 7.2367 us/op
+WorkloadResult  65: 32768 op, 192697931.00 ns, 5.8807 us/op
+WorkloadResult  66: 32768 op, 161904935.00 ns, 4.9409 us/op
+WorkloadResult  67: 32768 op, 245628678.00 ns, 7.4960 us/op
+WorkloadResult  68: 32768 op, 165169771.00 ns, 5.0406 us/op
+WorkloadResult  69: 32768 op, 119206241.00 ns, 3.6379 us/op
+WorkloadResult  70: 32768 op, 162056272.00 ns, 4.9456 us/op
+WorkloadResult  71: 32768 op, 220782135.00 ns, 6.7377 us/op
+WorkloadResult  72: 32768 op, 239770491.00 ns, 7.3172 us/op
+WorkloadResult  73: 32768 op, 131855109.00 ns, 4.0239 us/op
+WorkloadResult  74: 32768 op, 128215087.00 ns, 3.9128 us/op
+WorkloadResult  75: 32768 op, 117864118.00 ns, 3.5969 us/op
+WorkloadResult  76: 32768 op, 121676927.00 ns, 3.7133 us/op
+WorkloadResult  77: 32768 op, 119086789.00 ns, 3.6342 us/op
+WorkloadResult  78: 32768 op, 198617407.00 ns, 6.0613 us/op
+WorkloadResult  79: 32768 op, 126097440.00 ns, 3.8482 us/op
+WorkloadResult  80: 32768 op, 131397242.00 ns, 4.0099 us/op
+WorkloadResult  81: 32768 op, 127457892.00 ns, 3.8897 us/op
+WorkloadResult  82: 32768 op, 138089257.00 ns, 4.2141 us/op
+WorkloadResult  83: 32768 op, 116040003.00 ns, 3.5413 us/op
+WorkloadResult  84: 32768 op, 124001641.00 ns, 3.7842 us/op
+WorkloadResult  85: 32768 op, 115359385.00 ns, 3.5205 us/op
+WorkloadResult  86: 32768 op, 119332877.00 ns, 3.6418 us/op
+WorkloadResult  87: 32768 op, 137307651.00 ns, 4.1903 us/op
+WorkloadResult  88: 32768 op, 126224072.00 ns, 3.8521 us/op
+WorkloadResult  89: 32768 op, 156466602.00 ns, 4.7750 us/op
+WorkloadResult  90: 32768 op, 140675741.00 ns, 4.2931 us/op
+WorkloadResult  91: 32768 op, 113248439.00 ns, 3.4561 us/op
+GC:  5 0 0 49283744 32768
+Threading:  0 0 32768
+
+// AfterAll
+// Benchmark Process 1256961 has exited with code 0.
+
+Mean = 4.655 us, StdErr = 0.106 us (2.27%), N = 91, StdDev = 1.009 us
+Min = 3.456 us, Q1 = 3.921 us, Median = 4.450 us, Q3 = 5.045 us, Max = 7.575 us
+IQR = 1.124 us, LowerFence = 2.235 us, UpperFence = 6.732 us
+ConfidenceInterval = [4.295 us; 5.015 us] (CI 99.9%), Margin = 0.360 us (7.73% of Mean)
+Skewness = 1.17, Kurtosis = 3.75, MValue = 3.48
+
+// **************************
+// Benchmark: CountBenchmarks.List: DefaultJob [N=10]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.List(N: 10)" --job "Default" --benchmarkId 1 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 657908.00 ns, 657.9080 us/op
+WorkloadJitting  1: 1 op, 13251787.00 ns, 13.2518 ms/op
+
+OverheadJitting  2: 16 op, 895283.00 ns, 55.9552 us/op
+WorkloadJitting  2: 16 op, 3232742.00 ns, 202.0464 us/op
+
+WorkloadPilot    1: 16 op, 256435.00 ns, 16.0272 us/op
+WorkloadPilot    2: 32 op, 421442.00 ns, 13.1701 us/op
+WorkloadPilot    3: 64 op, 3451759.00 ns, 53.9337 us/op
+WorkloadPilot    4: 128 op, 5228726.00 ns, 40.8494 us/op
+WorkloadPilot    5: 256 op, 10005873.00 ns, 39.0854 us/op
+WorkloadPilot    6: 512 op, 20798738.00 ns, 40.6225 us/op
+WorkloadPilot    7: 1024 op, 42784766.00 ns, 41.7820 us/op
+WorkloadPilot    8: 2048 op, 90626625.00 ns, 44.2513 us/op
+WorkloadPilot    9: 4096 op, 161455672.00 ns, 39.4179 us/op
+WorkloadPilot   10: 8192 op, 302536730.00 ns, 36.9308 us/op
+WorkloadPilot   11: 16384 op, 538897586.00 ns, 32.8917 us/op
+
+OverheadWarmup   1: 16384 op, 595830.00 ns, 36.3666 ns/op
+OverheadWarmup   2: 16384 op, 588999.00 ns, 35.9496 ns/op
+OverheadWarmup   3: 16384 op, 1892210.00 ns, 115.4913 ns/op
+OverheadWarmup   4: 16384 op, 774085.00 ns, 47.2464 ns/op
+OverheadWarmup   5: 16384 op, 829196.00 ns, 50.6101 ns/op
+OverheadWarmup   6: 16384 op, 763268.00 ns, 46.5862 ns/op
+
+OverheadActual   1: 16384 op, 747322.00 ns, 45.6129 ns/op
+OverheadActual   2: 16384 op, 752194.00 ns, 45.9103 ns/op
+OverheadActual   3: 16384 op, 1678497.00 ns, 102.4473 ns/op
+OverheadActual   4: 16384 op, 8445019.00 ns, 515.4431 ns/op
+OverheadActual   5: 16384 op, 1452330.00 ns, 88.6432 ns/op
+OverheadActual   6: 16384 op, 910584.00 ns, 55.5776 ns/op
+OverheadActual   7: 16384 op, 1779899.00 ns, 108.6364 ns/op
+OverheadActual   8: 16384 op, 683639.00 ns, 41.7260 ns/op
+OverheadActual   9: 16384 op, 757957.00 ns, 46.2620 ns/op
+OverheadActual  10: 16384 op, 595633.00 ns, 36.3546 ns/op
+OverheadActual  11: 16384 op, 1614640.00 ns, 98.5498 ns/op
+OverheadActual  12: 16384 op, 587868.00 ns, 35.8806 ns/op
+OverheadActual  13: 16384 op, 584185.00 ns, 35.6558 ns/op
+OverheadActual  14: 16384 op, 611612.00 ns, 37.3298 ns/op
+OverheadActual  15: 16384 op, 596594.00 ns, 36.4132 ns/op
+OverheadActual  16: 16384 op, 1684451.00 ns, 102.8107 ns/op
+OverheadActual  17: 16384 op, 697530.00 ns, 42.5739 ns/op
+OverheadActual  18: 16384 op, 766123.00 ns, 46.7604 ns/op
+OverheadActual  19: 16384 op, 1767652.00 ns, 107.8889 ns/op
+OverheadActual  20: 16384 op, 1967760.00 ns, 120.1025 ns/op
+
+WorkloadWarmup   1: 16384 op, 688252239.00 ns, 42.0076 us/op
+WorkloadWarmup   2: 16384 op, 411874507.00 ns, 25.1388 us/op
+WorkloadWarmup   3: 16384 op, 435128667.00 ns, 26.5581 us/op
+WorkloadWarmup   4: 16384 op, 156682403.00 ns, 9.5631 us/op
+WorkloadWarmup   5: 16384 op, 79121943.00 ns, 4.8292 us/op
+WorkloadWarmup   6: 16384 op, 76509675.00 ns, 4.6698 us/op
+WorkloadWarmup   7: 16384 op, 90211714.00 ns, 5.5061 us/op
+WorkloadWarmup   8: 16384 op, 91212045.00 ns, 5.5671 us/op
+WorkloadWarmup   9: 16384 op, 116679839.00 ns, 7.1216 us/op
+WorkloadWarmup  10: 16384 op, 115912394.00 ns, 7.0747 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 16384 op, 87448054.00 ns, 5.3374 us/op
+WorkloadActual   2: 16384 op, 75558876.00 ns, 4.6117 us/op
+WorkloadActual   3: 16384 op, 64718487.00 ns, 3.9501 us/op
+WorkloadActual   4: 16384 op, 75223304.00 ns, 4.5913 us/op
+WorkloadActual   5: 16384 op, 79603812.00 ns, 4.8586 us/op
+WorkloadActual   6: 16384 op, 80255205.00 ns, 4.8984 us/op
+WorkloadActual   7: 16384 op, 72287378.00 ns, 4.4121 us/op
+WorkloadActual   8: 16384 op, 86761322.00 ns, 5.2955 us/op
+WorkloadActual   9: 16384 op, 65191296.00 ns, 3.9790 us/op
+WorkloadActual  10: 16384 op, 72976343.00 ns, 4.4541 us/op
+WorkloadActual  11: 16384 op, 76507498.00 ns, 4.6696 us/op
+WorkloadActual  12: 16384 op, 75082901.00 ns, 4.5827 us/op
+WorkloadActual  13: 16384 op, 80634637.00 ns, 4.9215 us/op
+WorkloadActual  14: 16384 op, 75148032.00 ns, 4.5867 us/op
+WorkloadActual  15: 16384 op, 66231551.00 ns, 4.0425 us/op
+WorkloadActual  16: 16384 op, 70803236.00 ns, 4.3215 us/op
+WorkloadActual  17: 16384 op, 73407709.00 ns, 4.4805 us/op
+WorkloadActual  18: 16384 op, 60858299.00 ns, 3.7145 us/op
+WorkloadActual  19: 16384 op, 68948835.00 ns, 4.2083 us/op
+WorkloadActual  20: 16384 op, 71236735.00 ns, 4.3479 us/op
+WorkloadActual  21: 16384 op, 92747174.00 ns, 5.6608 us/op
+WorkloadActual  22: 16384 op, 80177841.00 ns, 4.8937 us/op
+WorkloadActual  23: 16384 op, 77609588.00 ns, 4.7369 us/op
+WorkloadActual  24: 16384 op, 97105634.00 ns, 5.9269 us/op
+WorkloadActual  25: 16384 op, 92466177.00 ns, 5.6437 us/op
+WorkloadActual  26: 16384 op, 102683928.00 ns, 6.2673 us/op
+WorkloadActual  27: 16384 op, 78655060.00 ns, 4.8007 us/op
+WorkloadActual  28: 16384 op, 68239937.00 ns, 4.1650 us/op
+WorkloadActual  29: 16384 op, 60696372.00 ns, 3.7046 us/op
+WorkloadActual  30: 16384 op, 73151864.00 ns, 4.4648 us/op
+WorkloadActual  31: 16384 op, 67394209.00 ns, 4.1134 us/op
+WorkloadActual  32: 16384 op, 66427851.00 ns, 4.0544 us/op
+WorkloadActual  33: 16384 op, 73955833.00 ns, 4.5139 us/op
+WorkloadActual  34: 16384 op, 68586869.00 ns, 4.1862 us/op
+WorkloadActual  35: 16384 op, 65436590.00 ns, 3.9939 us/op
+WorkloadActual  36: 16384 op, 76379913.00 ns, 4.6619 us/op
+WorkloadActual  37: 16384 op, 164027577.00 ns, 10.0114 us/op
+WorkloadActual  38: 16384 op, 165096416.00 ns, 10.0767 us/op
+WorkloadActual  39: 16384 op, 59794808.00 ns, 3.6496 us/op
+WorkloadActual  40: 16384 op, 68748885.00 ns, 4.1961 us/op
+WorkloadActual  41: 16384 op, 73646923.00 ns, 4.4951 us/op
+WorkloadActual  42: 16384 op, 68462398.00 ns, 4.1786 us/op
+WorkloadActual  43: 16384 op, 77519669.00 ns, 4.7314 us/op
+WorkloadActual  44: 16384 op, 89715273.00 ns, 5.4758 us/op
+WorkloadActual  45: 16384 op, 84362916.00 ns, 5.1491 us/op
+WorkloadActual  46: 16384 op, 76473848.00 ns, 4.6676 us/op
+WorkloadActual  47: 16384 op, 101212710.00 ns, 6.1775 us/op
+WorkloadActual  48: 16384 op, 105434146.00 ns, 6.4352 us/op
+WorkloadActual  49: 16384 op, 80416761.00 ns, 4.9082 us/op
+WorkloadActual  50: 16384 op, 78327211.00 ns, 4.7807 us/op
+WorkloadActual  51: 16384 op, 70575957.00 ns, 4.3076 us/op
+WorkloadActual  52: 16384 op, 69693131.00 ns, 4.2537 us/op
+WorkloadActual  53: 16384 op, 65773492.00 ns, 4.0145 us/op
+WorkloadActual  54: 16384 op, 64432911.00 ns, 3.9327 us/op
+WorkloadActual  55: 16384 op, 79680146.00 ns, 4.8633 us/op
+WorkloadActual  56: 16384 op, 63047603.00 ns, 3.8481 us/op
+WorkloadActual  57: 16384 op, 65096056.00 ns, 3.9731 us/op
+WorkloadActual  58: 16384 op, 58588995.00 ns, 3.5760 us/op
+WorkloadActual  59: 16384 op, 76378718.00 ns, 4.6618 us/op
+WorkloadActual  60: 16384 op, 68574555.00 ns, 4.1855 us/op
+WorkloadActual  61: 16384 op, 64951006.00 ns, 3.9643 us/op
+WorkloadActual  62: 16384 op, 69171999.00 ns, 4.2219 us/op
+WorkloadActual  63: 16384 op, 74075606.00 ns, 4.5212 us/op
+WorkloadActual  64: 16384 op, 123160873.00 ns, 7.5171 us/op
+WorkloadActual  65: 16384 op, 108881270.00 ns, 6.6456 us/op
+WorkloadActual  66: 16384 op, 96465413.00 ns, 5.8878 us/op
+WorkloadActual  67: 16384 op, 100626936.00 ns, 6.1418 us/op
+WorkloadActual  68: 16384 op, 110270790.00 ns, 6.7304 us/op
+WorkloadActual  69: 16384 op, 73041918.00 ns, 4.4581 us/op
+WorkloadActual  70: 16384 op, 71938337.00 ns, 4.3908 us/op
+WorkloadActual  71: 16384 op, 78676910.00 ns, 4.8021 us/op
+WorkloadActual  72: 16384 op, 98619528.00 ns, 6.0193 us/op
+WorkloadActual  73: 16384 op, 88654349.00 ns, 5.4110 us/op
+WorkloadActual  74: 16384 op, 69394772.00 ns, 4.2355 us/op
+WorkloadActual  75: 16384 op, 70839058.00 ns, 4.3237 us/op
+WorkloadActual  76: 16384 op, 84743752.00 ns, 5.1723 us/op
+WorkloadActual  77: 16384 op, 66411003.00 ns, 4.0534 us/op
+WorkloadActual  78: 16384 op, 76429741.00 ns, 4.6649 us/op
+WorkloadActual  79: 16384 op, 72073789.00 ns, 4.3990 us/op
+WorkloadActual  80: 16384 op, 70261338.00 ns, 4.2884 us/op
+WorkloadActual  81: 16384 op, 64714491.00 ns, 3.9499 us/op
+WorkloadActual  82: 16384 op, 66105778.00 ns, 4.0348 us/op
+WorkloadActual  83: 16384 op, 77556139.00 ns, 4.7337 us/op
+WorkloadActual  84: 16384 op, 73040276.00 ns, 4.4580 us/op
+WorkloadActual  85: 16384 op, 61118721.00 ns, 3.7304 us/op
+WorkloadActual  86: 16384 op, 76092709.00 ns, 4.6443 us/op
+WorkloadActual  87: 16384 op, 85271606.00 ns, 5.2046 us/op
+WorkloadActual  88: 16384 op, 65634249.00 ns, 4.0060 us/op
+WorkloadActual  89: 16384 op, 59821695.00 ns, 3.6512 us/op
+WorkloadActual  90: 16384 op, 69265641.00 ns, 4.2276 us/op
+WorkloadActual  91: 16384 op, 90073847.00 ns, 5.4977 us/op
+WorkloadActual  92: 16384 op, 67400029.00 ns, 4.1138 us/op
+WorkloadActual  93: 16384 op, 69003773.00 ns, 4.2117 us/op
+WorkloadActual  94: 16384 op, 108980256.00 ns, 6.6516 us/op
+WorkloadActual  95: 16384 op, 113329912.00 ns, 6.9171 us/op
+WorkloadActual  96: 16384 op, 148641578.00 ns, 9.0724 us/op
+WorkloadActual  97: 16384 op, 132149997.00 ns, 8.0658 us/op
+WorkloadActual  98: 16384 op, 83678516.00 ns, 5.1073 us/op
+WorkloadActual  99: 16384 op, 63200674.00 ns, 3.8575 us/op
+WorkloadActual  100: 16384 op, 68066012.00 ns, 4.1544 us/op
+
+// AfterActualRun
+WorkloadResult   1: 16384 op, 86686014.00 ns, 5.2909 us/op
+WorkloadResult   2: 16384 op, 74796836.00 ns, 4.5652 us/op
+WorkloadResult   3: 16384 op, 63956447.00 ns, 3.9036 us/op
+WorkloadResult   4: 16384 op, 74461264.00 ns, 4.5448 us/op
+WorkloadResult   5: 16384 op, 78841772.00 ns, 4.8121 us/op
+WorkloadResult   6: 16384 op, 79493165.00 ns, 4.8519 us/op
+WorkloadResult   7: 16384 op, 71525338.00 ns, 4.3656 us/op
+WorkloadResult   8: 16384 op, 85999282.00 ns, 5.2490 us/op
+WorkloadResult   9: 16384 op, 64429256.00 ns, 3.9324 us/op
+WorkloadResult  10: 16384 op, 72214303.00 ns, 4.4076 us/op
+WorkloadResult  11: 16384 op, 75745458.00 ns, 4.6231 us/op
+WorkloadResult  12: 16384 op, 74320861.00 ns, 4.5362 us/op
+WorkloadResult  13: 16384 op, 79872597.00 ns, 4.8750 us/op
+WorkloadResult  14: 16384 op, 74385992.00 ns, 4.5402 us/op
+WorkloadResult  15: 16384 op, 65469511.00 ns, 3.9959 us/op
+WorkloadResult  16: 16384 op, 70041196.00 ns, 4.2750 us/op
+WorkloadResult  17: 16384 op, 72645669.00 ns, 4.4339 us/op
+WorkloadResult  18: 16384 op, 60096259.00 ns, 3.6680 us/op
+WorkloadResult  19: 16384 op, 68186795.00 ns, 4.1618 us/op
+WorkloadResult  20: 16384 op, 70474695.00 ns, 4.3014 us/op
+WorkloadResult  21: 16384 op, 91985134.00 ns, 5.6143 us/op
+WorkloadResult  22: 16384 op, 79415801.00 ns, 4.8472 us/op
+WorkloadResult  23: 16384 op, 76847548.00 ns, 4.6904 us/op
+WorkloadResult  24: 16384 op, 96343594.00 ns, 5.8803 us/op
+WorkloadResult  25: 16384 op, 91704137.00 ns, 5.5972 us/op
+WorkloadResult  26: 16384 op, 101921888.00 ns, 6.2208 us/op
+WorkloadResult  27: 16384 op, 77893020.00 ns, 4.7542 us/op
+WorkloadResult  28: 16384 op, 67477897.00 ns, 4.1185 us/op
+WorkloadResult  29: 16384 op, 59934332.00 ns, 3.6581 us/op
+WorkloadResult  30: 16384 op, 72389824.00 ns, 4.4183 us/op
+WorkloadResult  31: 16384 op, 66632169.00 ns, 4.0669 us/op
+WorkloadResult  32: 16384 op, 65665811.00 ns, 4.0079 us/op
+WorkloadResult  33: 16384 op, 73193793.00 ns, 4.4674 us/op
+WorkloadResult  34: 16384 op, 67824829.00 ns, 4.1397 us/op
+WorkloadResult  35: 16384 op, 64674550.00 ns, 3.9474 us/op
+WorkloadResult  36: 16384 op, 75617873.00 ns, 4.6153 us/op
+WorkloadResult  37: 16384 op, 59032768.00 ns, 3.6031 us/op
+WorkloadResult  38: 16384 op, 67986845.00 ns, 4.1496 us/op
+WorkloadResult  39: 16384 op, 72884883.00 ns, 4.4485 us/op
+WorkloadResult  40: 16384 op, 67700358.00 ns, 4.1321 us/op
+WorkloadResult  41: 16384 op, 76757629.00 ns, 4.6849 us/op
+WorkloadResult  42: 16384 op, 88953233.00 ns, 5.4293 us/op
+WorkloadResult  43: 16384 op, 83600876.00 ns, 5.1026 us/op
+WorkloadResult  44: 16384 op, 75711808.00 ns, 4.6211 us/op
+WorkloadResult  45: 16384 op, 100450670.00 ns, 6.1310 us/op
+WorkloadResult  46: 16384 op, 104672106.00 ns, 6.3887 us/op
+WorkloadResult  47: 16384 op, 79654721.00 ns, 4.8617 us/op
+WorkloadResult  48: 16384 op, 77565171.00 ns, 4.7342 us/op
+WorkloadResult  49: 16384 op, 69813917.00 ns, 4.2611 us/op
+WorkloadResult  50: 16384 op, 68931091.00 ns, 4.2072 us/op
+WorkloadResult  51: 16384 op, 65011452.00 ns, 3.9680 us/op
+WorkloadResult  52: 16384 op, 63670871.00 ns, 3.8862 us/op
+WorkloadResult  53: 16384 op, 78918106.00 ns, 4.8168 us/op
+WorkloadResult  54: 16384 op, 62285563.00 ns, 3.8016 us/op
+WorkloadResult  55: 16384 op, 64334016.00 ns, 3.9266 us/op
+WorkloadResult  56: 16384 op, 57826955.00 ns, 3.5295 us/op
+WorkloadResult  57: 16384 op, 75616678.00 ns, 4.6153 us/op
+WorkloadResult  58: 16384 op, 67812515.00 ns, 4.1389 us/op
+WorkloadResult  59: 16384 op, 64188966.00 ns, 3.9178 us/op
+WorkloadResult  60: 16384 op, 68409959.00 ns, 4.1754 us/op
+WorkloadResult  61: 16384 op, 73313566.00 ns, 4.4747 us/op
+WorkloadResult  62: 16384 op, 95703373.00 ns, 5.8413 us/op
+WorkloadResult  63: 16384 op, 99864896.00 ns, 6.0953 us/op
+WorkloadResult  64: 16384 op, 72279878.00 ns, 4.4116 us/op
+WorkloadResult  65: 16384 op, 71176297.00 ns, 4.3443 us/op
+WorkloadResult  66: 16384 op, 77914870.00 ns, 4.7555 us/op
+WorkloadResult  67: 16384 op, 97857488.00 ns, 5.9727 us/op
+WorkloadResult  68: 16384 op, 87892309.00 ns, 5.3645 us/op
+WorkloadResult  69: 16384 op, 68632732.00 ns, 4.1890 us/op
+WorkloadResult  70: 16384 op, 70077018.00 ns, 4.2772 us/op
+WorkloadResult  71: 16384 op, 83981712.00 ns, 5.1258 us/op
+WorkloadResult  72: 16384 op, 65648963.00 ns, 4.0069 us/op
+WorkloadResult  73: 16384 op, 75667701.00 ns, 4.6184 us/op
+WorkloadResult  74: 16384 op, 71311749.00 ns, 4.3525 us/op
+WorkloadResult  75: 16384 op, 69499298.00 ns, 4.2419 us/op
+WorkloadResult  76: 16384 op, 63952451.00 ns, 3.9033 us/op
+WorkloadResult  77: 16384 op, 65343738.00 ns, 3.9883 us/op
+WorkloadResult  78: 16384 op, 76794099.00 ns, 4.6871 us/op
+WorkloadResult  79: 16384 op, 72278236.00 ns, 4.4115 us/op
+WorkloadResult  80: 16384 op, 60356681.00 ns, 3.6839 us/op
+WorkloadResult  81: 16384 op, 75330669.00 ns, 4.5978 us/op
+WorkloadResult  82: 16384 op, 84509566.00 ns, 5.1581 us/op
+WorkloadResult  83: 16384 op, 64872209.00 ns, 3.9595 us/op
+WorkloadResult  84: 16384 op, 59059655.00 ns, 3.6047 us/op
+WorkloadResult  85: 16384 op, 68503601.00 ns, 4.1811 us/op
+WorkloadResult  86: 16384 op, 89311807.00 ns, 5.4512 us/op
+WorkloadResult  87: 16384 op, 66637989.00 ns, 4.0673 us/op
+WorkloadResult  88: 16384 op, 68241733.00 ns, 4.1651 us/op
+WorkloadResult  89: 16384 op, 82916476.00 ns, 5.0608 us/op
+WorkloadResult  90: 16384 op, 62438634.00 ns, 3.8110 us/op
+WorkloadResult  91: 16384 op, 67303972.00 ns, 4.1079 us/op
+GC:  3 0 0 29885088 16384
+Threading:  0 0 16384
+
+// AfterAll
+// Benchmark Process 1257031 has exited with code 0.
+
+Mean = 4.536 us, StdErr = 0.068 us (1.50%), N = 91, StdDev = 0.649 us
+Min = 3.529 us, Q1 = 4.088 us, Median = 4.412 us, Q3 = 4.814 us, Max = 6.389 us
+IQR = 0.727 us, LowerFence = 2.997 us, UpperFence = 5.905 us
+ConfidenceInterval = [4.305 us; 4.768 us] (CI 99.9%), Margin = 0.232 us (5.10% of Mean)
+Skewness = 0.96, Kurtosis = 3.39, MValue = 3.69
+
+// **************************
+// Benchmark: CountBenchmarks.ListWithCapacity: DefaultJob [N=10]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.ListWithCapacity(N: 10)" --job "Default" --benchmarkId 2 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 1919687.00 ns, 1.9197 ms/op
+WorkloadJitting  1: 1 op, 20763423.00 ns, 20.7634 ms/op
+
+OverheadJitting  2: 16 op, 2401595.00 ns, 150.0997 us/op
+WorkloadJitting  2: 16 op, 2828715.00 ns, 176.7947 us/op
+
+WorkloadPilot    1: 16 op, 419737.00 ns, 26.2336 us/op
+WorkloadPilot    2: 32 op, 662809.00 ns, 20.7128 us/op
+WorkloadPilot    3: 64 op, 2630953.00 ns, 41.1086 us/op
+WorkloadPilot    4: 128 op, 4462130.00 ns, 34.8604 us/op
+WorkloadPilot    5: 256 op, 10155243.00 ns, 39.6689 us/op
+WorkloadPilot    6: 512 op, 20479228.00 ns, 39.9985 us/op
+WorkloadPilot    7: 1024 op, 36523827.00 ns, 35.6678 us/op
+WorkloadPilot    8: 2048 op, 67585672.00 ns, 33.0008 us/op
+WorkloadPilot    9: 4096 op, 151508699.00 ns, 36.9894 us/op
+WorkloadPilot   10: 8192 op, 318448090.00 ns, 38.8731 us/op
+WorkloadPilot   11: 16384 op, 726751801.00 ns, 44.3574 us/op
+
+OverheadWarmup   1: 16384 op, 711787.00 ns, 43.4440 ns/op
+OverheadWarmup   2: 16384 op, 711057.00 ns, 43.3995 ns/op
+OverheadWarmup   3: 16384 op, 726371.00 ns, 44.3342 ns/op
+OverheadWarmup   4: 16384 op, 1688069.00 ns, 103.0316 ns/op
+OverheadWarmup   5: 16384 op, 786430.00 ns, 47.9999 ns/op
+OverheadWarmup   6: 16384 op, 849890.00 ns, 51.8732 ns/op
+OverheadWarmup   7: 16384 op, 1863604.00 ns, 113.7454 ns/op
+OverheadWarmup   8: 16384 op, 782813.00 ns, 47.7791 ns/op
+
+OverheadActual   1: 16384 op, 793853.00 ns, 48.4529 ns/op
+OverheadActual   2: 16384 op, 6706264.00 ns, 409.3179 ns/op
+OverheadActual   3: 16384 op, 716546.00 ns, 43.7345 ns/op
+OverheadActual   4: 16384 op, 1650522.00 ns, 100.7399 ns/op
+OverheadActual   5: 16384 op, 1744616.00 ns, 106.4829 ns/op
+OverheadActual   6: 16384 op, 2003253.00 ns, 122.2689 ns/op
+OverheadActual   7: 16384 op, 1983366.00 ns, 121.0551 ns/op
+OverheadActual   8: 16384 op, 1969612.00 ns, 120.2156 ns/op
+OverheadActual   9: 16384 op, 1876918.00 ns, 114.5580 ns/op
+OverheadActual  10: 16384 op, 1954932.00 ns, 119.3196 ns/op
+OverheadActual  11: 16384 op, 818454.00 ns, 49.9545 ns/op
+OverheadActual  12: 16384 op, 815770.00 ns, 49.7906 ns/op
+OverheadActual  13: 16384 op, 1127108.00 ns, 68.7932 ns/op
+OverheadActual  14: 16384 op, 1706922.00 ns, 104.1823 ns/op
+OverheadActual  15: 16384 op, 1650269.00 ns, 100.7244 ns/op
+OverheadActual  16: 16384 op, 627551.00 ns, 38.3027 ns/op
+OverheadActual  17: 16384 op, 837068.00 ns, 51.0906 ns/op
+OverheadActual  18: 16384 op, 1725667.00 ns, 105.3264 ns/op
+OverheadActual  19: 16384 op, 687375.00 ns, 41.9540 ns/op
+OverheadActual  20: 16384 op, 658966.00 ns, 40.2201 ns/op
+
+WorkloadWarmup   1: 16384 op, 514067459.00 ns, 31.3762 us/op
+WorkloadWarmup   2: 16384 op, 519297238.00 ns, 31.6954 us/op
+WorkloadWarmup   3: 16384 op, 462466986.00 ns, 28.2267 us/op
+WorkloadWarmup   4: 16384 op, 126899757.00 ns, 7.7453 us/op
+WorkloadWarmup   5: 16384 op, 67943108.00 ns, 4.1469 us/op
+WorkloadWarmup   6: 16384 op, 89796833.00 ns, 5.4808 us/op
+WorkloadWarmup   7: 16384 op, 83604592.00 ns, 5.1028 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 16384 op, 84489997.00 ns, 5.1569 us/op
+WorkloadActual   2: 16384 op, 81774117.00 ns, 4.9911 us/op
+WorkloadActual   3: 16384 op, 87731535.00 ns, 5.3547 us/op
+WorkloadActual   4: 16384 op, 90666085.00 ns, 5.5338 us/op
+WorkloadActual   5: 16384 op, 75658151.00 ns, 4.6178 us/op
+WorkloadActual   6: 16384 op, 72477442.00 ns, 4.4237 us/op
+WorkloadActual   7: 16384 op, 65287407.00 ns, 3.9848 us/op
+WorkloadActual   8: 16384 op, 56406546.00 ns, 3.4428 us/op
+WorkloadActual   9: 16384 op, 70569530.00 ns, 4.3072 us/op
+WorkloadActual  10: 16384 op, 70777214.00 ns, 4.3199 us/op
+WorkloadActual  11: 16384 op, 64095140.00 ns, 3.9121 us/op
+WorkloadActual  12: 16384 op, 60829697.00 ns, 3.7128 us/op
+WorkloadActual  13: 16384 op, 63671553.00 ns, 3.8862 us/op
+WorkloadActual  14: 16384 op, 61088420.00 ns, 3.7285 us/op
+WorkloadActual  15: 16384 op, 61764378.00 ns, 3.7698 us/op
+WorkloadActual  16: 16384 op, 68052152.00 ns, 4.1536 us/op
+WorkloadActual  17: 16384 op, 64135738.00 ns, 3.9145 us/op
+WorkloadActual  18: 16384 op, 64098077.00 ns, 3.9122 us/op
+WorkloadActual  19: 16384 op, 67280619.00 ns, 4.1065 us/op
+WorkloadActual  20: 16384 op, 72786734.00 ns, 4.4425 us/op
+WorkloadActual  21: 16384 op, 71053029.00 ns, 4.3367 us/op
+WorkloadActual  22: 16384 op, 93616039.00 ns, 5.7139 us/op
+WorkloadActual  23: 16384 op, 75383669.00 ns, 4.6011 us/op
+WorkloadActual  24: 16384 op, 91952794.00 ns, 5.6124 us/op
+WorkloadActual  25: 16384 op, 90946606.00 ns, 5.5509 us/op
+WorkloadActual  26: 16384 op, 99086117.00 ns, 6.0477 us/op
+WorkloadActual  27: 16384 op, 141283471.00 ns, 8.6233 us/op
+WorkloadActual  28: 16384 op, 81433023.00 ns, 4.9703 us/op
+WorkloadActual  29: 16384 op, 78844312.00 ns, 4.8123 us/op
+WorkloadActual  30: 16384 op, 77865604.00 ns, 4.7525 us/op
+WorkloadActual  31: 16384 op, 69311719.00 ns, 4.2305 us/op
+WorkloadActual  32: 16384 op, 89565072.00 ns, 5.4666 us/op
+WorkloadActual  33: 16384 op, 101677407.00 ns, 6.2059 us/op
+WorkloadActual  34: 16384 op, 99816311.00 ns, 6.0923 us/op
+WorkloadActual  35: 16384 op, 60463091.00 ns, 3.6904 us/op
+WorkloadActual  36: 16384 op, 95854820.00 ns, 5.8505 us/op
+WorkloadActual  37: 16384 op, 66627046.00 ns, 4.0666 us/op
+WorkloadActual  38: 16384 op, 85605811.00 ns, 5.2250 us/op
+WorkloadActual  39: 16384 op, 104450502.00 ns, 6.3752 us/op
+WorkloadActual  40: 16384 op, 68050398.00 ns, 4.1535 us/op
+WorkloadActual  41: 16384 op, 60166089.00 ns, 3.6722 us/op
+WorkloadActual  42: 16384 op, 79275243.00 ns, 4.8386 us/op
+WorkloadActual  43: 16384 op, 53905465.00 ns, 3.2901 us/op
+WorkloadActual  44: 16384 op, 62558836.00 ns, 3.8183 us/op
+WorkloadActual  45: 16384 op, 72062484.00 ns, 4.3983 us/op
+WorkloadActual  46: 16384 op, 64286821.00 ns, 3.9238 us/op
+WorkloadActual  47: 16384 op, 103202595.00 ns, 6.2990 us/op
+WorkloadActual  48: 16384 op, 89501309.00 ns, 5.4627 us/op
+WorkloadActual  49: 16384 op, 112625971.00 ns, 6.8741 us/op
+WorkloadActual  50: 16384 op, 94722463.00 ns, 5.7814 us/op
+WorkloadActual  51: 16384 op, 89026691.00 ns, 5.4338 us/op
+WorkloadActual  52: 16384 op, 61892348.00 ns, 3.7776 us/op
+WorkloadActual  53: 16384 op, 70409657.00 ns, 4.2975 us/op
+WorkloadActual  54: 16384 op, 61416449.00 ns, 3.7486 us/op
+WorkloadActual  55: 16384 op, 105128723.00 ns, 6.4165 us/op
+WorkloadActual  56: 16384 op, 73793067.00 ns, 4.5040 us/op
+WorkloadActual  57: 16384 op, 70226665.00 ns, 4.2863 us/op
+WorkloadActual  58: 16384 op, 72819624.00 ns, 4.4446 us/op
+WorkloadActual  59: 16384 op, 73105465.00 ns, 4.4620 us/op
+WorkloadActual  60: 16384 op, 89319681.00 ns, 5.4516 us/op
+WorkloadActual  61: 16384 op, 71826671.00 ns, 4.3840 us/op
+WorkloadActual  62: 16384 op, 83300302.00 ns, 5.0842 us/op
+WorkloadActual  63: 16384 op, 79022899.00 ns, 4.8232 us/op
+WorkloadActual  64: 16384 op, 79578139.00 ns, 4.8571 us/op
+WorkloadActual  65: 16384 op, 55790585.00 ns, 3.4052 us/op
+WorkloadActual  66: 16384 op, 58753498.00 ns, 3.5860 us/op
+WorkloadActual  67: 16384 op, 76272982.00 ns, 4.6553 us/op
+WorkloadActual  68: 16384 op, 60397185.00 ns, 3.6864 us/op
+WorkloadActual  69: 16384 op, 68314079.00 ns, 4.1696 us/op
+WorkloadActual  70: 16384 op, 74562052.00 ns, 4.5509 us/op
+WorkloadActual  71: 16384 op, 74413903.00 ns, 4.5419 us/op
+WorkloadActual  72: 16384 op, 66770669.00 ns, 4.0754 us/op
+WorkloadActual  73: 16384 op, 72693787.00 ns, 4.4369 us/op
+WorkloadActual  74: 16384 op, 58106047.00 ns, 3.5465 us/op
+WorkloadActual  75: 16384 op, 64033750.00 ns, 3.9083 us/op
+WorkloadActual  76: 16384 op, 64556497.00 ns, 3.9402 us/op
+WorkloadActual  77: 16384 op, 88103329.00 ns, 5.3774 us/op
+WorkloadActual  78: 16384 op, 99840908.00 ns, 6.0938 us/op
+WorkloadActual  79: 16384 op, 104142971.00 ns, 6.3564 us/op
+WorkloadActual  80: 16384 op, 66372298.00 ns, 4.0510 us/op
+WorkloadActual  81: 16384 op, 57180828.00 ns, 3.4900 us/op
+WorkloadActual  82: 16384 op, 84025093.00 ns, 5.1285 us/op
+WorkloadActual  83: 16384 op, 102125994.00 ns, 6.2333 us/op
+WorkloadActual  84: 16384 op, 86246442.00 ns, 5.2641 us/op
+WorkloadActual  85: 16384 op, 54818942.00 ns, 3.3459 us/op
+WorkloadActual  86: 16384 op, 57810708.00 ns, 3.5285 us/op
+WorkloadActual  87: 16384 op, 53155874.00 ns, 3.2444 us/op
+WorkloadActual  88: 16384 op, 62111297.00 ns, 3.7910 us/op
+WorkloadActual  89: 16384 op, 67817559.00 ns, 4.1393 us/op
+WorkloadActual  90: 16384 op, 69748206.00 ns, 4.2571 us/op
+WorkloadActual  91: 16384 op, 69702639.00 ns, 4.2543 us/op
+WorkloadActual  92: 16384 op, 71722535.00 ns, 4.3776 us/op
+WorkloadActual  93: 16384 op, 73390858.00 ns, 4.4794 us/op
+WorkloadActual  94: 16384 op, 74614687.00 ns, 4.5541 us/op
+WorkloadActual  95: 16384 op, 62973745.00 ns, 3.8436 us/op
+WorkloadActual  96: 16384 op, 77884766.00 ns, 4.7537 us/op
+WorkloadActual  97: 16384 op, 82581319.00 ns, 5.0404 us/op
+WorkloadActual  98: 16384 op, 51870833.00 ns, 3.1659 us/op
+WorkloadActual  99: 16384 op, 58487695.00 ns, 3.5698 us/op
+WorkloadActual  100: 16384 op, 70097484.00 ns, 4.2784 us/op
+
+// AfterActualRun
+WorkloadResult   1: 16384 op, 82839601.50 ns, 5.0561 us/op
+WorkloadResult   2: 16384 op, 80123721.50 ns, 4.8904 us/op
+WorkloadResult   3: 16384 op, 86081139.50 ns, 5.2540 us/op
+WorkloadResult   4: 16384 op, 89015689.50 ns, 5.4331 us/op
+WorkloadResult   5: 16384 op, 74007755.50 ns, 4.5171 us/op
+WorkloadResult   6: 16384 op, 70827046.50 ns, 4.3229 us/op
+WorkloadResult   7: 16384 op, 63637011.50 ns, 3.8841 us/op
+WorkloadResult   8: 16384 op, 54756150.50 ns, 3.3421 us/op
+WorkloadResult   9: 16384 op, 68919134.50 ns, 4.2065 us/op
+WorkloadResult  10: 16384 op, 69126818.50 ns, 4.2192 us/op
+WorkloadResult  11: 16384 op, 62444744.50 ns, 3.8113 us/op
+WorkloadResult  12: 16384 op, 59179301.50 ns, 3.6120 us/op
+WorkloadResult  13: 16384 op, 62021157.50 ns, 3.7855 us/op
+WorkloadResult  14: 16384 op, 59438024.50 ns, 3.6278 us/op
+WorkloadResult  15: 16384 op, 60113982.50 ns, 3.6691 us/op
+WorkloadResult  16: 16384 op, 66401756.50 ns, 4.0528 us/op
+WorkloadResult  17: 16384 op, 62485342.50 ns, 3.8138 us/op
+WorkloadResult  18: 16384 op, 62447681.50 ns, 3.8115 us/op
+WorkloadResult  19: 16384 op, 65630223.50 ns, 4.0058 us/op
+WorkloadResult  20: 16384 op, 71136338.50 ns, 4.3418 us/op
+WorkloadResult  21: 16384 op, 69402633.50 ns, 4.2360 us/op
+WorkloadResult  22: 16384 op, 91965643.50 ns, 5.6131 us/op
+WorkloadResult  23: 16384 op, 73733273.50 ns, 4.5003 us/op
+WorkloadResult  24: 16384 op, 90302398.50 ns, 5.5116 us/op
+WorkloadResult  25: 16384 op, 89296210.50 ns, 5.4502 us/op
+WorkloadResult  26: 16384 op, 97435721.50 ns, 5.9470 us/op
+WorkloadResult  27: 16384 op, 79782627.50 ns, 4.8695 us/op
+WorkloadResult  28: 16384 op, 77193916.50 ns, 4.7115 us/op
+WorkloadResult  29: 16384 op, 76215208.50 ns, 4.6518 us/op
+WorkloadResult  30: 16384 op, 67661323.50 ns, 4.1297 us/op
+WorkloadResult  31: 16384 op, 87914676.50 ns, 5.3659 us/op
+WorkloadResult  32: 16384 op, 100027011.50 ns, 6.1052 us/op
+WorkloadResult  33: 16384 op, 98165915.50 ns, 5.9916 us/op
+WorkloadResult  34: 16384 op, 58812695.50 ns, 3.5896 us/op
+WorkloadResult  35: 16384 op, 94204424.50 ns, 5.7498 us/op
+WorkloadResult  36: 16384 op, 64976650.50 ns, 3.9659 us/op
+WorkloadResult  37: 16384 op, 83955415.50 ns, 5.1242 us/op
+WorkloadResult  38: 16384 op, 102800106.50 ns, 6.2744 us/op
+WorkloadResult  39: 16384 op, 66400002.50 ns, 4.0527 us/op
+WorkloadResult  40: 16384 op, 58515693.50 ns, 3.5715 us/op
+WorkloadResult  41: 16384 op, 77624847.50 ns, 4.7378 us/op
+WorkloadResult  42: 16384 op, 52255069.50 ns, 3.1894 us/op
+WorkloadResult  43: 16384 op, 60908440.50 ns, 3.7176 us/op
+WorkloadResult  44: 16384 op, 70412088.50 ns, 4.2976 us/op
+WorkloadResult  45: 16384 op, 62636425.50 ns, 3.8230 us/op
+WorkloadResult  46: 16384 op, 101552199.50 ns, 6.1983 us/op
+WorkloadResult  47: 16384 op, 87850913.50 ns, 5.3620 us/op
+WorkloadResult  48: 16384 op, 110975575.50 ns, 6.7734 us/op
+WorkloadResult  49: 16384 op, 93072067.50 ns, 5.6807 us/op
+WorkloadResult  50: 16384 op, 87376295.50 ns, 5.3330 us/op
+WorkloadResult  51: 16384 op, 60241952.50 ns, 3.6769 us/op
+WorkloadResult  52: 16384 op, 68759261.50 ns, 4.1967 us/op
+WorkloadResult  53: 16384 op, 59766053.50 ns, 3.6478 us/op
+WorkloadResult  54: 16384 op, 103478327.50 ns, 6.3158 us/op
+WorkloadResult  55: 16384 op, 72142671.50 ns, 4.4032 us/op
+WorkloadResult  56: 16384 op, 68576269.50 ns, 4.1856 us/op
+WorkloadResult  57: 16384 op, 71169228.50 ns, 4.3438 us/op
+WorkloadResult  58: 16384 op, 71455069.50 ns, 4.3613 us/op
+WorkloadResult  59: 16384 op, 87669285.50 ns, 5.3509 us/op
+WorkloadResult  60: 16384 op, 70176275.50 ns, 4.2832 us/op
+WorkloadResult  61: 16384 op, 81649906.50 ns, 4.9835 us/op
+WorkloadResult  62: 16384 op, 77372503.50 ns, 4.7224 us/op
+WorkloadResult  63: 16384 op, 77927743.50 ns, 4.7563 us/op
+WorkloadResult  64: 16384 op, 54140189.50 ns, 3.3045 us/op
+WorkloadResult  65: 16384 op, 57103102.50 ns, 3.4853 us/op
+WorkloadResult  66: 16384 op, 74622586.50 ns, 4.5546 us/op
+WorkloadResult  67: 16384 op, 58746789.50 ns, 3.5856 us/op
+WorkloadResult  68: 16384 op, 66663683.50 ns, 4.0688 us/op
+WorkloadResult  69: 16384 op, 72911656.50 ns, 4.4502 us/op
+WorkloadResult  70: 16384 op, 72763507.50 ns, 4.4411 us/op
+WorkloadResult  71: 16384 op, 65120273.50 ns, 3.9746 us/op
+WorkloadResult  72: 16384 op, 71043391.50 ns, 4.3361 us/op
+WorkloadResult  73: 16384 op, 56455651.50 ns, 3.4458 us/op
+WorkloadResult  74: 16384 op, 62383354.50 ns, 3.8076 us/op
+WorkloadResult  75: 16384 op, 62906101.50 ns, 3.8395 us/op
+WorkloadResult  76: 16384 op, 86452933.50 ns, 5.2767 us/op
+WorkloadResult  77: 16384 op, 98190512.50 ns, 5.9931 us/op
+WorkloadResult  78: 16384 op, 102492575.50 ns, 6.2557 us/op
+WorkloadResult  79: 16384 op, 64721902.50 ns, 3.9503 us/op
+WorkloadResult  80: 16384 op, 55530432.50 ns, 3.3893 us/op
+WorkloadResult  81: 16384 op, 82374697.50 ns, 5.0278 us/op
+WorkloadResult  82: 16384 op, 100475598.50 ns, 6.1325 us/op
+WorkloadResult  83: 16384 op, 84596046.50 ns, 5.1633 us/op
+WorkloadResult  84: 16384 op, 53168546.50 ns, 3.2452 us/op
+WorkloadResult  85: 16384 op, 56160312.50 ns, 3.4278 us/op
+WorkloadResult  86: 16384 op, 51505478.50 ns, 3.1436 us/op
+WorkloadResult  87: 16384 op, 60460901.50 ns, 3.6902 us/op
+WorkloadResult  88: 16384 op, 66167163.50 ns, 4.0385 us/op
+WorkloadResult  89: 16384 op, 68097810.50 ns, 4.1564 us/op
+WorkloadResult  90: 16384 op, 68052243.50 ns, 4.1536 us/op
+WorkloadResult  91: 16384 op, 70072139.50 ns, 4.2769 us/op
+WorkloadResult  92: 16384 op, 71740462.50 ns, 4.3787 us/op
+WorkloadResult  93: 16384 op, 72964291.50 ns, 4.4534 us/op
+WorkloadResult  94: 16384 op, 61323349.50 ns, 3.7429 us/op
+WorkloadResult  95: 16384 op, 76234370.50 ns, 4.6530 us/op
+WorkloadResult  96: 16384 op, 80930923.50 ns, 4.9396 us/op
+WorkloadResult  97: 16384 op, 50220437.50 ns, 3.0652 us/op
+WorkloadResult  98: 16384 op, 56837299.50 ns, 3.4691 us/op
+WorkloadResult  99: 16384 op, 68447088.50 ns, 4.1777 us/op
+GC:  2 0 0 25036096 16384
+Threading:  0 0 16384
+
+// AfterAll
+// Benchmark Process 1257056 has exited with code 0.
+
+Mean = 4.474 us, StdErr = 0.087 us (1.94%), N = 99, StdDev = 0.864 us
+Min = 3.065 us, Q1 = 3.811 us, Median = 4.298 us, Q3 = 5.042 us, Max = 6.773 us
+IQR = 1.231 us, LowerFence = 1.966 us, UpperFence = 6.888 us
+ConfidenceInterval = [4.179 us; 4.768 us] (CI 99.9%), Margin = 0.295 us (6.58% of Mean)
+Skewness = 0.63, Kurtosis = 2.55, MValue = 2.41
+
+// **************************
+// Benchmark: CountBenchmarks.Array: DefaultJob [N=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.Array(N: 100)" --job "Default" --benchmarkId 3 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 1791165.00 ns, 1.7912 ms/op
+WorkloadJitting  1: 1 op, 16180482.00 ns, 16.1805 ms/op
+
+OverheadJitting  2: 16 op, 2361825.00 ns, 147.6141 us/op
+WorkloadJitting  2: 16 op, 4824864.00 ns, 301.5540 us/op
+
+WorkloadPilot    1: 16 op, 3541012.00 ns, 221.3133 us/op
+WorkloadPilot    2: 32 op, 5930952.00 ns, 185.3423 us/op
+WorkloadPilot    3: 64 op, 13396237.00 ns, 209.3162 us/op
+WorkloadPilot    4: 128 op, 25592255.00 ns, 199.9395 us/op
+WorkloadPilot    5: 256 op, 60664221.00 ns, 236.9696 us/op
+WorkloadPilot    6: 512 op, 121524780.00 ns, 237.3531 us/op
+WorkloadPilot    7: 1024 op, 206154236.00 ns, 201.3225 us/op
+WorkloadPilot    8: 2048 op, 539148761.00 ns, 263.2562 us/op
+
+OverheadWarmup   1: 2048 op, 119889.00 ns, 58.5396 ns/op
+OverheadWarmup   2: 2048 op, 75828.00 ns, 37.0254 ns/op
+OverheadWarmup   3: 2048 op, 119137.00 ns, 58.1724 ns/op
+OverheadWarmup   4: 2048 op, 138472.00 ns, 67.6133 ns/op
+OverheadWarmup   5: 2048 op, 118060.00 ns, 57.6465 ns/op
+OverheadWarmup   6: 2048 op, 73248.00 ns, 35.7656 ns/op
+OverheadWarmup   7: 2048 op, 117343.00 ns, 57.2964 ns/op
+OverheadWarmup   8: 2048 op, 112540.00 ns, 54.9512 ns/op
+
+OverheadActual   1: 2048 op, 74710.00 ns, 36.4795 ns/op
+OverheadActual   2: 2048 op, 121575.00 ns, 59.3628 ns/op
+OverheadActual   3: 2048 op, 116790.00 ns, 57.0264 ns/op
+OverheadActual   4: 2048 op, 119244.00 ns, 58.2246 ns/op
+OverheadActual   5: 2048 op, 91759.00 ns, 44.8042 ns/op
+OverheadActual   6: 2048 op, 166550.00 ns, 81.3232 ns/op
+OverheadActual   7: 2048 op, 100160.00 ns, 48.9062 ns/op
+OverheadActual   8: 2048 op, 92775.00 ns, 45.3003 ns/op
+OverheadActual   9: 2048 op, 89477.00 ns, 43.6899 ns/op
+OverheadActual  10: 2048 op, 73818.00 ns, 36.0439 ns/op
+OverheadActual  11: 2048 op, 74238.00 ns, 36.2490 ns/op
+OverheadActual  12: 2048 op, 80970.00 ns, 39.5361 ns/op
+OverheadActual  13: 2048 op, 102928.00 ns, 50.2578 ns/op
+OverheadActual  14: 2048 op, 71740.00 ns, 35.0293 ns/op
+OverheadActual  15: 2048 op, 72907.00 ns, 35.5991 ns/op
+OverheadActual  16: 2048 op, 106566.00 ns, 52.0342 ns/op
+OverheadActual  17: 2048 op, 80388.00 ns, 39.2520 ns/op
+OverheadActual  18: 2048 op, 75065.00 ns, 36.6528 ns/op
+OverheadActual  19: 2048 op, 107307.00 ns, 52.3960 ns/op
+OverheadActual  20: 2048 op, 81480.00 ns, 39.7852 ns/op
+
+WorkloadWarmup   1: 2048 op, 400153122.00 ns, 195.3873 us/op
+WorkloadWarmup   2: 2048 op, 445759961.00 ns, 217.6562 us/op
+WorkloadWarmup   3: 2048 op, 475141107.00 ns, 232.0025 us/op
+WorkloadWarmup   4: 2048 op, 430908340.00 ns, 210.4045 us/op
+WorkloadWarmup   5: 2048 op, 117116837.00 ns, 57.1860 us/op
+WorkloadWarmup   6: 2048 op, 105769566.00 ns, 51.6453 us/op
+WorkloadWarmup   7: 2048 op, 70534435.00 ns, 34.4406 us/op
+WorkloadWarmup   8: 2048 op, 65585258.00 ns, 32.0241 us/op
+WorkloadWarmup   9: 2048 op, 55302158.00 ns, 27.0030 us/op
+WorkloadWarmup  10: 2048 op, 63960546.00 ns, 31.2307 us/op
+WorkloadWarmup  11: 2048 op, 65755109.00 ns, 32.1070 us/op
+WorkloadWarmup  12: 2048 op, 63220995.00 ns, 30.8696 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 2048 op, 83113384.00 ns, 40.5827 us/op
+WorkloadActual   2: 2048 op, 66033693.00 ns, 32.2430 us/op
+WorkloadActual   3: 2048 op, 68696023.00 ns, 33.5430 us/op
+WorkloadActual   4: 2048 op, 68650808.00 ns, 33.5209 us/op
+WorkloadActual   5: 2048 op, 64429153.00 ns, 31.4595 us/op
+WorkloadActual   6: 2048 op, 63466756.00 ns, 30.9896 us/op
+WorkloadActual   7: 2048 op, 59225204.00 ns, 28.9186 us/op
+WorkloadActual   8: 2048 op, 67334989.00 ns, 32.8784 us/op
+WorkloadActual   9: 2048 op, 51649719.00 ns, 25.2196 us/op
+WorkloadActual  10: 2048 op, 56694815.00 ns, 27.6830 us/op
+WorkloadActual  11: 2048 op, 53068702.00 ns, 25.9125 us/op
+WorkloadActual  12: 2048 op, 54121739.00 ns, 26.4266 us/op
+WorkloadActual  13: 2048 op, 55151503.00 ns, 26.9294 us/op
+WorkloadActual  14: 2048 op, 52772321.00 ns, 25.7677 us/op
+WorkloadActual  15: 2048 op, 54060092.00 ns, 26.3965 us/op
+WorkloadActual  16: 2048 op, 48768435.00 ns, 23.8127 us/op
+WorkloadActual  17: 2048 op, 58263076.00 ns, 28.4488 us/op
+WorkloadActual  18: 2048 op, 61094664.00 ns, 29.8314 us/op
+WorkloadActual  19: 2048 op, 60772209.00 ns, 29.6739 us/op
+WorkloadActual  20: 2048 op, 64164946.00 ns, 31.3305 us/op
+WorkloadActual  21: 2048 op, 55456224.00 ns, 27.0782 us/op
+WorkloadActual  22: 2048 op, 74994989.00 ns, 36.6186 us/op
+WorkloadActual  23: 2048 op, 65726333.00 ns, 32.0929 us/op
+WorkloadActual  24: 2048 op, 52487884.00 ns, 25.6288 us/op
+WorkloadActual  25: 2048 op, 81312829.00 ns, 39.7035 us/op
+WorkloadActual  26: 2048 op, 48200786.00 ns, 23.5355 us/op
+WorkloadActual  27: 2048 op, 54094227.00 ns, 26.4132 us/op
+WorkloadActual  28: 2048 op, 50613373.00 ns, 24.7136 us/op
+WorkloadActual  29: 2048 op, 48612469.00 ns, 23.7366 us/op
+WorkloadActual  30: 2048 op, 62162810.00 ns, 30.3529 us/op
+WorkloadActual  31: 2048 op, 58537681.00 ns, 28.5829 us/op
+WorkloadActual  32: 2048 op, 61771713.00 ns, 30.1620 us/op
+WorkloadActual  33: 2048 op, 54989645.00 ns, 26.8504 us/op
+WorkloadActual  34: 2048 op, 59210840.00 ns, 28.9115 us/op
+WorkloadActual  35: 2048 op, 58519586.00 ns, 28.5740 us/op
+WorkloadActual  36: 2048 op, 57521246.00 ns, 28.0865 us/op
+WorkloadActual  37: 2048 op, 57286614.00 ns, 27.9720 us/op
+WorkloadActual  38: 2048 op, 63186974.00 ns, 30.8530 us/op
+WorkloadActual  39: 2048 op, 122212141.00 ns, 59.6739 us/op
+WorkloadActual  40: 2048 op, 108468109.00 ns, 52.9629 us/op
+WorkloadActual  41: 2048 op, 98430673.00 ns, 48.0619 us/op
+WorkloadActual  42: 2048 op, 57351832.00 ns, 28.0038 us/op
+WorkloadActual  43: 2048 op, 51985745.00 ns, 25.3837 us/op
+WorkloadActual  44: 2048 op, 60727109.00 ns, 29.6519 us/op
+WorkloadActual  45: 2048 op, 63594843.00 ns, 31.0522 us/op
+WorkloadActual  46: 2048 op, 54481493.00 ns, 26.6023 us/op
+WorkloadActual  47: 2048 op, 68095184.00 ns, 33.2496 us/op
+WorkloadActual  48: 2048 op, 60602865.00 ns, 29.5912 us/op
+WorkloadActual  49: 2048 op, 54611711.00 ns, 26.6659 us/op
+WorkloadActual  50: 2048 op, 82900697.00 ns, 40.4789 us/op
+WorkloadActual  51: 2048 op, 63237739.00 ns, 30.8778 us/op
+WorkloadActual  52: 2048 op, 61480699.00 ns, 30.0199 us/op
+WorkloadActual  53: 2048 op, 56143067.00 ns, 27.4136 us/op
+WorkloadActual  54: 2048 op, 55668138.00 ns, 27.1817 us/op
+WorkloadActual  55: 2048 op, 46878620.00 ns, 22.8900 us/op
+WorkloadActual  56: 2048 op, 87746232.00 ns, 42.8448 us/op
+WorkloadActual  57: 2048 op, 85194754.00 ns, 41.5990 us/op
+WorkloadActual  58: 2048 op, 84698824.00 ns, 41.3568 us/op
+WorkloadActual  59: 2048 op, 83725088.00 ns, 40.8814 us/op
+WorkloadActual  60: 2048 op, 109467064.00 ns, 53.4507 us/op
+WorkloadActual  61: 2048 op, 85048457.00 ns, 41.5276 us/op
+WorkloadActual  62: 2048 op, 108534715.00 ns, 52.9955 us/op
+WorkloadActual  63: 2048 op, 54806717.00 ns, 26.7611 us/op
+WorkloadActual  64: 2048 op, 57778176.00 ns, 28.2120 us/op
+WorkloadActual  65: 2048 op, 50339346.00 ns, 24.5798 us/op
+WorkloadActual  66: 2048 op, 53395242.00 ns, 26.0719 us/op
+WorkloadActual  67: 2048 op, 54104231.00 ns, 26.4181 us/op
+WorkloadActual  68: 2048 op, 57711531.00 ns, 28.1795 us/op
+WorkloadActual  69: 2048 op, 55974273.00 ns, 27.3312 us/op
+WorkloadActual  70: 2048 op, 57542463.00 ns, 28.0969 us/op
+WorkloadActual  71: 2048 op, 60318954.00 ns, 29.4526 us/op
+WorkloadActual  72: 2048 op, 61240092.00 ns, 29.9024 us/op
+WorkloadActual  73: 2048 op, 66420601.00 ns, 32.4319 us/op
+WorkloadActual  74: 2048 op, 55638791.00 ns, 27.1674 us/op
+WorkloadActual  75: 2048 op, 53345659.00 ns, 26.0477 us/op
+WorkloadActual  76: 2048 op, 51635195.00 ns, 25.2125 us/op
+WorkloadActual  77: 2048 op, 54076548.00 ns, 26.4046 us/op
+WorkloadActual  78: 2048 op, 66097778.00 ns, 32.2743 us/op
+WorkloadActual  79: 2048 op, 50781812.00 ns, 24.7958 us/op
+WorkloadActual  80: 2048 op, 66125477.00 ns, 32.2878 us/op
+WorkloadActual  81: 2048 op, 69926815.00 ns, 34.1440 us/op
+WorkloadActual  82: 2048 op, 71165393.00 ns, 34.7487 us/op
+WorkloadActual  83: 2048 op, 70193394.00 ns, 34.2741 us/op
+WorkloadActual  84: 2048 op, 66792005.00 ns, 32.6133 us/op
+WorkloadActual  85: 2048 op, 72906743.00 ns, 35.5990 us/op
+WorkloadActual  86: 2048 op, 82966367.00 ns, 40.5109 us/op
+WorkloadActual  87: 2048 op, 107029056.00 ns, 52.2603 us/op
+WorkloadActual  88: 2048 op, 93448203.00 ns, 45.6290 us/op
+WorkloadActual  89: 2048 op, 100109492.00 ns, 48.8816 us/op
+WorkloadActual  90: 2048 op, 93852469.00 ns, 45.8264 us/op
+WorkloadActual  91: 2048 op, 51380127.00 ns, 25.0880 us/op
+WorkloadActual  92: 2048 op, 54142233.00 ns, 26.4366 us/op
+WorkloadActual  93: 2048 op, 61528285.00 ns, 30.0431 us/op
+WorkloadActual  94: 2048 op, 62471046.00 ns, 30.5034 us/op
+WorkloadActual  95: 2048 op, 56541436.00 ns, 27.6081 us/op
+WorkloadActual  96: 2048 op, 52903335.00 ns, 25.8317 us/op
+WorkloadActual  97: 2048 op, 67790166.00 ns, 33.1007 us/op
+WorkloadActual  98: 2048 op, 49052407.00 ns, 23.9514 us/op
+WorkloadActual  99: 2048 op, 54568994.00 ns, 26.6450 us/op
+WorkloadActual  100: 2048 op, 46526565.00 ns, 22.7180 us/op
+
+// AfterActualRun
+WorkloadResult   1: 2048 op, 83022766.00 ns, 40.5385 us/op
+WorkloadResult   2: 2048 op, 65943075.00 ns, 32.1988 us/op
+WorkloadResult   3: 2048 op, 68605405.00 ns, 33.4987 us/op
+WorkloadResult   4: 2048 op, 68560190.00 ns, 33.4767 us/op
+WorkloadResult   5: 2048 op, 64338535.00 ns, 31.4153 us/op
+WorkloadResult   6: 2048 op, 63376138.00 ns, 30.9454 us/op
+WorkloadResult   7: 2048 op, 59134586.00 ns, 28.8743 us/op
+WorkloadResult   8: 2048 op, 67244371.00 ns, 32.8342 us/op
+WorkloadResult   9: 2048 op, 51559101.00 ns, 25.1753 us/op
+WorkloadResult  10: 2048 op, 56604197.00 ns, 27.6388 us/op
+WorkloadResult  11: 2048 op, 52978084.00 ns, 25.8682 us/op
+WorkloadResult  12: 2048 op, 54031121.00 ns, 26.3824 us/op
+WorkloadResult  13: 2048 op, 55060885.00 ns, 26.8852 us/op
+WorkloadResult  14: 2048 op, 52681703.00 ns, 25.7235 us/op
+WorkloadResult  15: 2048 op, 53969474.00 ns, 26.3523 us/op
+WorkloadResult  16: 2048 op, 48677817.00 ns, 23.7685 us/op
+WorkloadResult  17: 2048 op, 58172458.00 ns, 28.4045 us/op
+WorkloadResult  18: 2048 op, 61004046.00 ns, 29.7871 us/op
+WorkloadResult  19: 2048 op, 60681591.00 ns, 29.6297 us/op
+WorkloadResult  20: 2048 op, 64074328.00 ns, 31.2863 us/op
+WorkloadResult  21: 2048 op, 55365606.00 ns, 27.0340 us/op
+WorkloadResult  22: 2048 op, 74904371.00 ns, 36.5744 us/op
+WorkloadResult  23: 2048 op, 65635715.00 ns, 32.0487 us/op
+WorkloadResult  24: 2048 op, 52397266.00 ns, 25.5846 us/op
+WorkloadResult  25: 2048 op, 81222211.00 ns, 39.6593 us/op
+WorkloadResult  26: 2048 op, 48110168.00 ns, 23.4913 us/op
+WorkloadResult  27: 2048 op, 54003609.00 ns, 26.3689 us/op
+WorkloadResult  28: 2048 op, 50522755.00 ns, 24.6693 us/op
+WorkloadResult  29: 2048 op, 48521851.00 ns, 23.6923 us/op
+WorkloadResult  30: 2048 op, 62072192.00 ns, 30.3087 us/op
+WorkloadResult  31: 2048 op, 58447063.00 ns, 28.5386 us/op
+WorkloadResult  32: 2048 op, 61681095.00 ns, 30.1177 us/op
+WorkloadResult  33: 2048 op, 54899027.00 ns, 26.8062 us/op
+WorkloadResult  34: 2048 op, 59120222.00 ns, 28.8673 us/op
+WorkloadResult  35: 2048 op, 58428968.00 ns, 28.5298 us/op
+WorkloadResult  36: 2048 op, 57430628.00 ns, 28.0423 us/op
+WorkloadResult  37: 2048 op, 57195996.00 ns, 27.9277 us/op
+WorkloadResult  38: 2048 op, 63096356.00 ns, 30.8088 us/op
+WorkloadResult  39: 2048 op, 57261214.00 ns, 27.9596 us/op
+WorkloadResult  40: 2048 op, 51895127.00 ns, 25.3394 us/op
+WorkloadResult  41: 2048 op, 60636491.00 ns, 29.6077 us/op
+WorkloadResult  42: 2048 op, 63504225.00 ns, 31.0079 us/op
+WorkloadResult  43: 2048 op, 54390875.00 ns, 26.5580 us/op
+WorkloadResult  44: 2048 op, 68004566.00 ns, 33.2054 us/op
+WorkloadResult  45: 2048 op, 60512247.00 ns, 29.5470 us/op
+WorkloadResult  46: 2048 op, 54521093.00 ns, 26.6216 us/op
+WorkloadResult  47: 2048 op, 82810079.00 ns, 40.4346 us/op
+WorkloadResult  48: 2048 op, 63147121.00 ns, 30.8336 us/op
+WorkloadResult  49: 2048 op, 61390081.00 ns, 29.9756 us/op
+WorkloadResult  50: 2048 op, 56052449.00 ns, 27.3694 us/op
+WorkloadResult  51: 2048 op, 55577520.00 ns, 27.1375 us/op
+WorkloadResult  52: 2048 op, 46788002.00 ns, 22.8457 us/op
+WorkloadResult  53: 2048 op, 87655614.00 ns, 42.8006 us/op
+WorkloadResult  54: 2048 op, 85104136.00 ns, 41.5548 us/op
+WorkloadResult  55: 2048 op, 84608206.00 ns, 41.3126 us/op
+WorkloadResult  56: 2048 op, 83634470.00 ns, 40.8371 us/op
+WorkloadResult  57: 2048 op, 84957839.00 ns, 41.4833 us/op
+WorkloadResult  58: 2048 op, 54716099.00 ns, 26.7168 us/op
+WorkloadResult  59: 2048 op, 57687558.00 ns, 28.1678 us/op
+WorkloadResult  60: 2048 op, 50248728.00 ns, 24.5355 us/op
+WorkloadResult  61: 2048 op, 53304624.00 ns, 26.0276 us/op
+WorkloadResult  62: 2048 op, 54013613.00 ns, 26.3738 us/op
+WorkloadResult  63: 2048 op, 57620913.00 ns, 28.1352 us/op
+WorkloadResult  64: 2048 op, 55883655.00 ns, 27.2869 us/op
+WorkloadResult  65: 2048 op, 57451845.00 ns, 28.0527 us/op
+WorkloadResult  66: 2048 op, 60228336.00 ns, 29.4084 us/op
+WorkloadResult  67: 2048 op, 61149474.00 ns, 29.8581 us/op
+WorkloadResult  68: 2048 op, 66329983.00 ns, 32.3877 us/op
+WorkloadResult  69: 2048 op, 55548173.00 ns, 27.1231 us/op
+WorkloadResult  70: 2048 op, 53255041.00 ns, 26.0034 us/op
+WorkloadResult  71: 2048 op, 51544577.00 ns, 25.1683 us/op
+WorkloadResult  72: 2048 op, 53985930.00 ns, 26.3603 us/op
+WorkloadResult  73: 2048 op, 66007160.00 ns, 32.2301 us/op
+WorkloadResult  74: 2048 op, 50691194.00 ns, 24.7516 us/op
+WorkloadResult  75: 2048 op, 66034859.00 ns, 32.2436 us/op
+WorkloadResult  76: 2048 op, 69836197.00 ns, 34.0997 us/op
+WorkloadResult  77: 2048 op, 71074775.00 ns, 34.7045 us/op
+WorkloadResult  78: 2048 op, 70102776.00 ns, 34.2299 us/op
+WorkloadResult  79: 2048 op, 66701387.00 ns, 32.5690 us/op
+WorkloadResult  80: 2048 op, 72816125.00 ns, 35.5547 us/op
+WorkloadResult  81: 2048 op, 82875749.00 ns, 40.4667 us/op
+WorkloadResult  82: 2048 op, 51289509.00 ns, 25.0437 us/op
+WorkloadResult  83: 2048 op, 54051615.00 ns, 26.3924 us/op
+WorkloadResult  84: 2048 op, 61437667.00 ns, 29.9989 us/op
+WorkloadResult  85: 2048 op, 62380428.00 ns, 30.4592 us/op
+WorkloadResult  86: 2048 op, 56450818.00 ns, 27.5639 us/op
+WorkloadResult  87: 2048 op, 52812717.00 ns, 25.7875 us/op
+WorkloadResult  88: 2048 op, 67699548.00 ns, 33.0564 us/op
+WorkloadResult  89: 2048 op, 48961789.00 ns, 23.9071 us/op
+WorkloadResult  90: 2048 op, 54478376.00 ns, 26.6008 us/op
+WorkloadResult  91: 2048 op, 46435947.00 ns, 22.6738 us/op
+GC:  2 0 0 20775584 2048
+Threading:  0 0 2048
+
+// AfterAll
+// Benchmark Process 1257081 has exited with code 0.
+
+Mean = 29.782 us, StdErr = 0.505 us (1.70%), N = 91, StdDev = 4.818 us
+Min = 22.674 us, Q1 = 26.378 us, Median = 28.530 us, Q3 = 32.214 us, Max = 42.801 us
+IQR = 5.836 us, LowerFence = 17.624 us, UpperFence = 40.969 us
+ConfidenceInterval = [28.063 us; 31.500 us] (CI 99.9%), Margin = 1.718 us (5.77% of Mean)
+Skewness = 1.06, Kurtosis = 3.49, MValue = 3
+
+// **************************
+// Benchmark: CountBenchmarks.List: DefaultJob [N=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.List(N: 100)" --job "Default" --benchmarkId 4 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 1860513.00 ns, 1.8605 ms/op
+WorkloadJitting  1: 1 op, 9590233.00 ns, 9.5902 ms/op
+
+OverheadJitting  2: 16 op, 1081164.00 ns, 67.5727 us/op
+WorkloadJitting  2: 16 op, 6051384.00 ns, 378.2115 us/op
+
+WorkloadPilot    1: 16 op, 2441063.00 ns, 152.5664 us/op
+WorkloadPilot    2: 32 op, 6040473.00 ns, 188.7648 us/op
+WorkloadPilot    3: 64 op, 12365538.00 ns, 193.2115 us/op
+WorkloadPilot    4: 128 op, 27903246.00 ns, 217.9941 us/op
+WorkloadPilot    5: 256 op, 57917088.00 ns, 226.2386 us/op
+WorkloadPilot    6: 512 op, 109069323.00 ns, 213.0260 us/op
+WorkloadPilot    7: 1024 op, 213853680.00 ns, 208.8415 us/op
+WorkloadPilot    8: 2048 op, 387496660.00 ns, 189.2074 us/op
+WorkloadPilot    9: 4096 op, 709138923.00 ns, 173.1296 us/op
+
+OverheadWarmup   1: 4096 op, 168670.00 ns, 41.1792 ns/op
+OverheadWarmup   2: 4096 op, 155962.00 ns, 38.0767 ns/op
+OverheadWarmup   3: 4096 op, 191212.00 ns, 46.6826 ns/op
+OverheadWarmup   4: 4096 op, 230520.00 ns, 56.2793 ns/op
+OverheadWarmup   5: 4096 op, 160639.00 ns, 39.2185 ns/op
+OverheadWarmup   6: 4096 op, 143287.00 ns, 34.9822 ns/op
+OverheadWarmup   7: 4096 op, 143280.00 ns, 34.9805 ns/op
+OverheadWarmup   8: 4096 op, 212731.00 ns, 51.9363 ns/op
+OverheadWarmup   9: 4096 op, 149028.00 ns, 36.3838 ns/op
+
+OverheadActual   1: 4096 op, 169432.00 ns, 41.3652 ns/op
+OverheadActual   2: 4096 op, 152265.00 ns, 37.1741 ns/op
+OverheadActual   3: 4096 op, 145108.00 ns, 35.4268 ns/op
+OverheadActual   4: 4096 op, 213808.00 ns, 52.1992 ns/op
+OverheadActual   5: 4096 op, 227655.00 ns, 55.5798 ns/op
+OverheadActual   6: 4096 op, 169372.00 ns, 41.3506 ns/op
+OverheadActual   7: 4096 op, 192835.00 ns, 47.0789 ns/op
+OverheadActual   8: 4096 op, 216442.00 ns, 52.8423 ns/op
+OverheadActual   9: 4096 op, 144343.00 ns, 35.2400 ns/op
+OverheadActual  10: 4096 op, 144051.00 ns, 35.1687 ns/op
+OverheadActual  11: 4096 op, 144702.00 ns, 35.3276 ns/op
+OverheadActual  12: 4096 op, 163738.00 ns, 39.9751 ns/op
+OverheadActual  13: 4096 op, 294079.00 ns, 71.7966 ns/op
+OverheadActual  14: 4096 op, 155826.00 ns, 38.0435 ns/op
+OverheadActual  15: 4096 op, 141943.00 ns, 34.6541 ns/op
+OverheadActual  16: 4096 op, 140765.00 ns, 34.3665 ns/op
+OverheadActual  17: 4096 op, 356398.00 ns, 87.0112 ns/op
+OverheadActual  18: 4096 op, 1242082.00 ns, 303.2427 ns/op
+OverheadActual  19: 4096 op, 162745.00 ns, 39.7327 ns/op
+OverheadActual  20: 4096 op, 151646.00 ns, 37.0229 ns/op
+
+WorkloadWarmup   1: 4096 op, 747463362.00 ns, 182.4862 us/op
+WorkloadWarmup   2: 4096 op, 815271406.00 ns, 199.0409 us/op
+WorkloadWarmup   3: 4096 op, 595076853.00 ns, 145.2824 us/op
+WorkloadWarmup   4: 4096 op, 139496893.00 ns, 34.0569 us/op
+WorkloadWarmup   5: 4096 op, 114286701.00 ns, 27.9020 us/op
+WorkloadWarmup   6: 4096 op, 112992611.00 ns, 27.5861 us/op
+WorkloadWarmup   7: 4096 op, 114344165.00 ns, 27.9161 us/op
+WorkloadWarmup   8: 4096 op, 121138862.00 ns, 29.5749 us/op
+WorkloadWarmup   9: 4096 op, 119493190.00 ns, 29.1731 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 4096 op, 117939293.00 ns, 28.7938 us/op
+WorkloadActual   2: 4096 op, 111168230.00 ns, 27.1407 us/op
+WorkloadActual   3: 4096 op, 113172808.00 ns, 27.6301 us/op
+WorkloadActual   4: 4096 op, 116692795.00 ns, 28.4895 us/op
+WorkloadActual   5: 4096 op, 127513780.00 ns, 31.1313 us/op
+WorkloadActual   6: 4096 op, 118787856.00 ns, 29.0009 us/op
+WorkloadActual   7: 4096 op, 118512890.00 ns, 28.9338 us/op
+WorkloadActual   8: 4096 op, 116444971.00 ns, 28.4289 us/op
+WorkloadActual   9: 4096 op, 116802308.00 ns, 28.5162 us/op
+WorkloadActual  10: 4096 op, 112219664.00 ns, 27.3974 us/op
+WorkloadActual  11: 4096 op, 114614444.00 ns, 27.9820 us/op
+WorkloadActual  12: 4096 op, 109519713.00 ns, 26.7382 us/op
+WorkloadActual  13: 4096 op, 113370947.00 ns, 27.6785 us/op
+WorkloadActual  14: 4096 op, 106245296.00 ns, 25.9388 us/op
+WorkloadActual  15: 4096 op, 118619363.00 ns, 28.9598 us/op
+WorkloadActual  16: 4096 op, 123620361.00 ns, 30.1808 us/op
+WorkloadActual  17: 4096 op, 186438403.00 ns, 45.5172 us/op
+WorkloadActual  18: 4096 op, 143736332.00 ns, 35.0919 us/op
+WorkloadActual  19: 4096 op, 123978647.00 ns, 30.2682 us/op
+WorkloadActual  20: 4096 op, 107136964.00 ns, 26.1565 us/op
+WorkloadActual  21: 4096 op, 113961347.00 ns, 27.8226 us/op
+WorkloadActual  22: 4096 op, 126494894.00 ns, 30.8825 us/op
+WorkloadActual  23: 4096 op, 113136121.00 ns, 27.6211 us/op
+WorkloadActual  24: 4096 op, 136706220.00 ns, 33.3755 us/op
+WorkloadActual  25: 4096 op, 125105730.00 ns, 30.5434 us/op
+WorkloadActual  26: 4096 op, 121008091.00 ns, 29.5430 us/op
+WorkloadActual  27: 4096 op, 113908467.00 ns, 27.8097 us/op
+WorkloadActual  28: 4096 op, 109459017.00 ns, 26.7234 us/op
+WorkloadActual  29: 4096 op, 107943833.00 ns, 26.3535 us/op
+WorkloadActual  30: 4096 op, 113031634.00 ns, 27.5956 us/op
+WorkloadActual  31: 4096 op, 121187285.00 ns, 29.5867 us/op
+WorkloadActual  32: 4096 op, 122968624.00 ns, 30.0216 us/op
+WorkloadActual  33: 4096 op, 142789456.00 ns, 34.8607 us/op
+WorkloadActual  34: 4096 op, 211333742.00 ns, 51.5952 us/op
+WorkloadActual  35: 4096 op, 181845083.00 ns, 44.3958 us/op
+WorkloadActual  36: 4096 op, 138460907.00 ns, 33.8039 us/op
+WorkloadActual  37: 4096 op, 110920888.00 ns, 27.0803 us/op
+WorkloadActual  38: 4096 op, 110519234.00 ns, 26.9822 us/op
+WorkloadActual  39: 4096 op, 169263410.00 ns, 41.3241 us/op
+WorkloadActual  40: 4096 op, 112279971.00 ns, 27.4121 us/op
+WorkloadActual  41: 4096 op, 110094370.00 ns, 26.8785 us/op
+WorkloadActual  42: 4096 op, 105243390.00 ns, 25.6942 us/op
+WorkloadActual  43: 4096 op, 166694501.00 ns, 40.6969 us/op
+WorkloadActual  44: 4096 op, 161539660.00 ns, 39.4384 us/op
+WorkloadActual  45: 4096 op, 120734292.00 ns, 29.4761 us/op
+WorkloadActual  46: 4096 op, 127812293.00 ns, 31.2042 us/op
+WorkloadActual  47: 4096 op, 105149644.00 ns, 25.6713 us/op
+WorkloadActual  48: 4096 op, 119693550.00 ns, 29.2221 us/op
+WorkloadActual  49: 4096 op, 142312388.00 ns, 34.7442 us/op
+WorkloadActual  50: 4096 op, 121903675.00 ns, 29.7616 us/op
+WorkloadActual  51: 4096 op, 111704071.00 ns, 27.2715 us/op
+WorkloadActual  52: 4096 op, 125383373.00 ns, 30.6112 us/op
+WorkloadActual  53: 4096 op, 123288960.00 ns, 30.0998 us/op
+WorkloadActual  54: 4096 op, 126884815.00 ns, 30.9777 us/op
+WorkloadActual  55: 4096 op, 164823539.00 ns, 40.2401 us/op
+WorkloadActual  56: 4096 op, 128319319.00 ns, 31.3280 us/op
+WorkloadActual  57: 4096 op, 131957103.00 ns, 32.2161 us/op
+WorkloadActual  58: 4096 op, 122014371.00 ns, 29.7887 us/op
+WorkloadActual  59: 4096 op, 126782698.00 ns, 30.9528 us/op
+WorkloadActual  60: 4096 op, 122808402.00 ns, 29.9825 us/op
+WorkloadActual  61: 4096 op, 133450555.00 ns, 32.5807 us/op
+WorkloadActual  62: 4096 op, 125521216.00 ns, 30.6448 us/op
+WorkloadActual  63: 4096 op, 108400585.00 ns, 26.4650 us/op
+WorkloadActual  64: 4096 op, 153062673.00 ns, 37.3688 us/op
+WorkloadActual  65: 4096 op, 118419413.00 ns, 28.9110 us/op
+WorkloadActual  66: 4096 op, 140875420.00 ns, 34.3934 us/op
+WorkloadActual  67: 4096 op, 147521099.00 ns, 36.0159 us/op
+WorkloadActual  68: 4096 op, 130523183.00 ns, 31.8660 us/op
+WorkloadActual  69: 4096 op, 126657567.00 ns, 30.9223 us/op
+WorkloadActual  70: 4096 op, 125069889.00 ns, 30.5346 us/op
+WorkloadActual  71: 4096 op, 121927753.00 ns, 29.7675 us/op
+WorkloadActual  72: 4096 op, 112893949.00 ns, 27.5620 us/op
+WorkloadActual  73: 4096 op, 171129091.00 ns, 41.7796 us/op
+WorkloadActual  74: 4096 op, 143294703.00 ns, 34.9841 us/op
+WorkloadActual  75: 4096 op, 144333951.00 ns, 35.2378 us/op
+WorkloadActual  76: 4096 op, 142385483.00 ns, 34.7621 us/op
+WorkloadActual  77: 4096 op, 140596851.00 ns, 34.3254 us/op
+WorkloadActual  78: 4096 op, 138467821.00 ns, 33.8056 us/op
+WorkloadActual  79: 4096 op, 132423134.00 ns, 32.3299 us/op
+WorkloadActual  80: 4096 op, 127443959.00 ns, 31.1142 us/op
+WorkloadActual  81: 4096 op, 111037066.00 ns, 27.1087 us/op
+WorkloadActual  82: 4096 op, 111560894.00 ns, 27.2365 us/op
+WorkloadActual  83: 4096 op, 149724656.00 ns, 36.5539 us/op
+WorkloadActual  84: 4096 op, 154101201.00 ns, 37.6224 us/op
+WorkloadActual  85: 4096 op, 114819849.00 ns, 28.0322 us/op
+WorkloadActual  86: 4096 op, 104254579.00 ns, 25.4528 us/op
+WorkloadActual  87: 4096 op, 128611632.00 ns, 31.3993 us/op
+WorkloadActual  88: 4096 op, 135582939.00 ns, 33.1013 us/op
+WorkloadActual  89: 4096 op, 116366511.00 ns, 28.4098 us/op
+WorkloadActual  90: 4096 op, 125288449.00 ns, 30.5880 us/op
+WorkloadActual  91: 4096 op, 132261864.00 ns, 32.2905 us/op
+WorkloadActual  92: 4096 op, 108362916.00 ns, 26.4558 us/op
+WorkloadActual  93: 4096 op, 123122709.00 ns, 30.0593 us/op
+WorkloadActual  94: 4096 op, 113137415.00 ns, 27.6214 us/op
+WorkloadActual  95: 4096 op, 117486694.00 ns, 28.6833 us/op
+WorkloadActual  96: 4096 op, 116866842.00 ns, 28.5319 us/op
+WorkloadActual  97: 4096 op, 118869058.00 ns, 29.0208 us/op
+WorkloadActual  98: 4096 op, 128465057.00 ns, 31.3635 us/op
+WorkloadActual  99: 4096 op, 140649749.00 ns, 34.3383 us/op
+WorkloadActual  100: 4096 op, 105285572.00 ns, 25.7045 us/op
+
+// AfterActualRun
+WorkloadResult   1: 4096 op, 117776051.50 ns, 28.7539 us/op
+WorkloadResult   2: 4096 op, 111004988.50 ns, 27.1008 us/op
+WorkloadResult   3: 4096 op, 113009566.50 ns, 27.5902 us/op
+WorkloadResult   4: 4096 op, 116529553.50 ns, 28.4496 us/op
+WorkloadResult   5: 4096 op, 127350538.50 ns, 31.0914 us/op
+WorkloadResult   6: 4096 op, 118624614.50 ns, 28.9611 us/op
+WorkloadResult   7: 4096 op, 118349648.50 ns, 28.8940 us/op
+WorkloadResult   8: 4096 op, 116281729.50 ns, 28.3891 us/op
+WorkloadResult   9: 4096 op, 116639066.50 ns, 28.4763 us/op
+WorkloadResult  10: 4096 op, 112056422.50 ns, 27.3575 us/op
+WorkloadResult  11: 4096 op, 114451202.50 ns, 27.9422 us/op
+WorkloadResult  12: 4096 op, 109356471.50 ns, 26.6984 us/op
+WorkloadResult  13: 4096 op, 113207705.50 ns, 27.6386 us/op
+WorkloadResult  14: 4096 op, 106082054.50 ns, 25.8989 us/op
+WorkloadResult  15: 4096 op, 118456121.50 ns, 28.9200 us/op
+WorkloadResult  16: 4096 op, 123457119.50 ns, 30.1409 us/op
+WorkloadResult  17: 4096 op, 143573090.50 ns, 35.0520 us/op
+WorkloadResult  18: 4096 op, 123815405.50 ns, 30.2284 us/op
+WorkloadResult  19: 4096 op, 106973722.50 ns, 26.1166 us/op
+WorkloadResult  20: 4096 op, 113798105.50 ns, 27.7827 us/op
+WorkloadResult  21: 4096 op, 126331652.50 ns, 30.8427 us/op
+WorkloadResult  22: 4096 op, 112972879.50 ns, 27.5813 us/op
+WorkloadResult  23: 4096 op, 136542978.50 ns, 33.3357 us/op
+WorkloadResult  24: 4096 op, 124942488.50 ns, 30.5035 us/op
+WorkloadResult  25: 4096 op, 120844849.50 ns, 29.5031 us/op
+WorkloadResult  26: 4096 op, 113745225.50 ns, 27.7698 us/op
+WorkloadResult  27: 4096 op, 109295775.50 ns, 26.6835 us/op
+WorkloadResult  28: 4096 op, 107780591.50 ns, 26.3136 us/op
+WorkloadResult  29: 4096 op, 112868392.50 ns, 27.5558 us/op
+WorkloadResult  30: 4096 op, 121024043.50 ns, 29.5469 us/op
+WorkloadResult  31: 4096 op, 122805382.50 ns, 29.9818 us/op
+WorkloadResult  32: 4096 op, 142626214.50 ns, 34.8209 us/op
+WorkloadResult  33: 4096 op, 138297665.50 ns, 33.7641 us/op
+WorkloadResult  34: 4096 op, 110757646.50 ns, 27.0404 us/op
+WorkloadResult  35: 4096 op, 110355992.50 ns, 26.9424 us/op
+WorkloadResult  36: 4096 op, 112116729.50 ns, 27.3722 us/op
+WorkloadResult  37: 4096 op, 109931128.50 ns, 26.8387 us/op
+WorkloadResult  38: 4096 op, 105080148.50 ns, 25.6543 us/op
+WorkloadResult  39: 4096 op, 161376418.50 ns, 39.3985 us/op
+WorkloadResult  40: 4096 op, 120571050.50 ns, 29.4363 us/op
+WorkloadResult  41: 4096 op, 127649051.50 ns, 31.1643 us/op
+WorkloadResult  42: 4096 op, 104986402.50 ns, 25.6314 us/op
+WorkloadResult  43: 4096 op, 119530308.50 ns, 29.1822 us/op
+WorkloadResult  44: 4096 op, 142149146.50 ns, 34.7044 us/op
+WorkloadResult  45: 4096 op, 121740433.50 ns, 29.7218 us/op
+WorkloadResult  46: 4096 op, 111540829.50 ns, 27.2316 us/op
+WorkloadResult  47: 4096 op, 125220131.50 ns, 30.5713 us/op
+WorkloadResult  48: 4096 op, 123125718.50 ns, 30.0600 us/op
+WorkloadResult  49: 4096 op, 126721573.50 ns, 30.9379 us/op
+WorkloadResult  50: 4096 op, 164660297.50 ns, 40.2003 us/op
+WorkloadResult  51: 4096 op, 128156077.50 ns, 31.2881 us/op
+WorkloadResult  52: 4096 op, 131793861.50 ns, 32.1762 us/op
+WorkloadResult  53: 4096 op, 121851129.50 ns, 29.7488 us/op
+WorkloadResult  54: 4096 op, 126619456.50 ns, 30.9130 us/op
+WorkloadResult  55: 4096 op, 122645160.50 ns, 29.9427 us/op
+WorkloadResult  56: 4096 op, 133287313.50 ns, 32.5408 us/op
+WorkloadResult  57: 4096 op, 125357974.50 ns, 30.6050 us/op
+WorkloadResult  58: 4096 op, 108237343.50 ns, 26.4251 us/op
+WorkloadResult  59: 4096 op, 152899431.50 ns, 37.3290 us/op
+WorkloadResult  60: 4096 op, 118256171.50 ns, 28.8711 us/op
+WorkloadResult  61: 4096 op, 140712178.50 ns, 34.3536 us/op
+WorkloadResult  62: 4096 op, 147357857.50 ns, 35.9760 us/op
+WorkloadResult  63: 4096 op, 130359941.50 ns, 31.8262 us/op
+WorkloadResult  64: 4096 op, 126494325.50 ns, 30.8824 us/op
+WorkloadResult  65: 4096 op, 124906647.50 ns, 30.4948 us/op
+WorkloadResult  66: 4096 op, 121764511.50 ns, 29.7277 us/op
+WorkloadResult  67: 4096 op, 112730707.50 ns, 27.5221 us/op
+WorkloadResult  68: 4096 op, 143131461.50 ns, 34.9442 us/op
+WorkloadResult  69: 4096 op, 144170709.50 ns, 35.1979 us/op
+WorkloadResult  70: 4096 op, 142222241.50 ns, 34.7222 us/op
+WorkloadResult  71: 4096 op, 140433609.50 ns, 34.2855 us/op
+WorkloadResult  72: 4096 op, 138304579.50 ns, 33.7658 us/op
+WorkloadResult  73: 4096 op, 132259892.50 ns, 32.2900 us/op
+WorkloadResult  74: 4096 op, 127280717.50 ns, 31.0744 us/op
+WorkloadResult  75: 4096 op, 110873824.50 ns, 27.0688 us/op
+WorkloadResult  76: 4096 op, 111397652.50 ns, 27.1967 us/op
+WorkloadResult  77: 4096 op, 149561414.50 ns, 36.5140 us/op
+WorkloadResult  78: 4096 op, 153937959.50 ns, 37.5825 us/op
+WorkloadResult  79: 4096 op, 114656607.50 ns, 27.9923 us/op
+WorkloadResult  80: 4096 op, 104091337.50 ns, 25.4129 us/op
+WorkloadResult  81: 4096 op, 128448390.50 ns, 31.3595 us/op
+WorkloadResult  82: 4096 op, 135419697.50 ns, 33.0614 us/op
+WorkloadResult  83: 4096 op, 116203269.50 ns, 28.3699 us/op
+WorkloadResult  84: 4096 op, 125125207.50 ns, 30.5481 us/op
+WorkloadResult  85: 4096 op, 132098622.50 ns, 32.2506 us/op
+WorkloadResult  86: 4096 op, 108199674.50 ns, 26.4159 us/op
+WorkloadResult  87: 4096 op, 122959467.50 ns, 30.0194 us/op
+WorkloadResult  88: 4096 op, 112974173.50 ns, 27.5816 us/op
+WorkloadResult  89: 4096 op, 117323452.50 ns, 28.6434 us/op
+WorkloadResult  90: 4096 op, 116703600.50 ns, 28.4921 us/op
+WorkloadResult  91: 4096 op, 118705816.50 ns, 28.9809 us/op
+WorkloadResult  92: 4096 op, 128301815.50 ns, 31.3237 us/op
+WorkloadResult  93: 4096 op, 140486507.50 ns, 34.2985 us/op
+WorkloadResult  94: 4096 op, 105122330.50 ns, 25.6646 us/op
+GC:  6 0 0 51938624 4096
+Threading:  0 0 4096
+
+// AfterAll
+// Benchmark Process 1257102 has exited with code 0.
+
+Mean = 30.186 us, StdErr = 0.336 us (1.11%), N = 94, StdDev = 3.260 us
+Min = 25.413 us, Q1 = 27.584 us, Median = 29.725 us, Q3 = 31.709 us, Max = 40.200 us
+IQR = 4.126 us, LowerFence = 21.395 us, UpperFence = 37.898 us
+ConfidenceInterval = [29.043 us; 31.328 us] (CI 99.9%), Margin = 1.142 us (3.78% of Mean)
+Skewness = 0.86, Kurtosis = 3.27, MValue = 4
+
+// **************************
+// Benchmark: CountBenchmarks.ListWithCapacity: DefaultJob [N=100]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.ListWithCapacity(N: 100)" --job "Default" --benchmarkId 5 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 632984.00 ns, 632.9840 us/op
+WorkloadJitting  1: 1 op, 15561225.00 ns, 15.5612 ms/op
+
+OverheadJitting  2: 16 op, 914868.00 ns, 57.1793 us/op
+WorkloadJitting  2: 16 op, 5716127.00 ns, 357.2579 us/op
+
+WorkloadPilot    1: 16 op, 2371888.00 ns, 148.2430 us/op
+WorkloadPilot    2: 32 op, 7626964.00 ns, 238.3426 us/op
+WorkloadPilot    3: 64 op, 14960577.00 ns, 233.7590 us/op
+WorkloadPilot    4: 128 op, 28255585.00 ns, 220.7468 us/op
+WorkloadPilot    5: 256 op, 47937635.00 ns, 187.2564 us/op
+WorkloadPilot    6: 512 op, 102638977.00 ns, 200.4668 us/op
+WorkloadPilot    7: 1024 op, 208582455.00 ns, 203.6938 us/op
+WorkloadPilot    8: 2048 op, 371140392.00 ns, 181.2209 us/op
+WorkloadPilot    9: 4096 op, 844545596.00 ns, 206.1879 us/op
+
+OverheadWarmup   1: 4096 op, 249416.00 ns, 60.8926 ns/op
+OverheadWarmup   2: 4096 op, 257582.00 ns, 62.8862 ns/op
+OverheadWarmup   3: 4096 op, 1251562.00 ns, 305.5571 ns/op
+OverheadWarmup   4: 4096 op, 219417.00 ns, 53.5686 ns/op
+OverheadWarmup   5: 4096 op, 223441.00 ns, 54.5510 ns/op
+OverheadWarmup   6: 4096 op, 283079.00 ns, 69.1111 ns/op
+OverheadWarmup   7: 4096 op, 228270.00 ns, 55.7300 ns/op
+
+OverheadActual   1: 4096 op, 248190.00 ns, 60.5933 ns/op
+OverheadActual   2: 4096 op, 175929.00 ns, 42.9514 ns/op
+OverheadActual   3: 4096 op, 219355.00 ns, 53.5535 ns/op
+OverheadActual   4: 4096 op, 167821.00 ns, 40.9719 ns/op
+OverheadActual   5: 4096 op, 201182.00 ns, 49.1167 ns/op
+OverheadActual   6: 4096 op, 223853.00 ns, 54.6516 ns/op
+OverheadActual   7: 4096 op, 186120.00 ns, 45.4395 ns/op
+OverheadActual   8: 4096 op, 224965.00 ns, 54.9231 ns/op
+OverheadActual   9: 4096 op, 144322.00 ns, 35.2349 ns/op
+OverheadActual  10: 4096 op, 221404.00 ns, 54.0537 ns/op
+OverheadActual  11: 4096 op, 194745.00 ns, 47.5452 ns/op
+OverheadActual  12: 4096 op, 230133.00 ns, 56.1848 ns/op
+OverheadActual  13: 4096 op, 225670.00 ns, 55.0952 ns/op
+OverheadActual  14: 4096 op, 236994.00 ns, 57.8599 ns/op
+OverheadActual  15: 4096 op, 202992.00 ns, 49.5586 ns/op
+OverheadActual  16: 4096 op, 178512.00 ns, 43.5820 ns/op
+OverheadActual  17: 4096 op, 227292.00 ns, 55.4912 ns/op
+OverheadActual  18: 4096 op, 170342.00 ns, 41.5874 ns/op
+OverheadActual  19: 4096 op, 199242.00 ns, 48.6431 ns/op
+OverheadActual  20: 4096 op, 214442.00 ns, 52.3540 ns/op
+
+WorkloadWarmup   1: 4096 op, 847789704.00 ns, 206.9799 us/op
+WorkloadWarmup   2: 4096 op, 717171575.00 ns, 175.0907 us/op
+WorkloadWarmup   3: 4096 op, 649047123.00 ns, 158.4588 us/op
+WorkloadWarmup   4: 4096 op, 263084310.00 ns, 64.2296 us/op
+WorkloadWarmup   5: 4096 op, 118411537.00 ns, 28.9091 us/op
+WorkloadWarmup   6: 4096 op, 105792343.00 ns, 25.8282 us/op
+WorkloadWarmup   7: 4096 op, 106312543.00 ns, 25.9552 us/op
+WorkloadWarmup   8: 4096 op, 110758231.00 ns, 27.0406 us/op
+WorkloadWarmup   9: 4096 op, 94889430.00 ns, 23.1664 us/op
+WorkloadWarmup  10: 4096 op, 102552243.00 ns, 25.0372 us/op
+WorkloadWarmup  11: 4096 op, 107666755.00 ns, 26.2858 us/op
+WorkloadWarmup  12: 4096 op, 162634609.00 ns, 39.7057 us/op
+WorkloadWarmup  13: 4096 op, 103263588.00 ns, 25.2108 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 4096 op, 125302619.00 ns, 30.5915 us/op
+WorkloadActual   2: 4096 op, 110211341.00 ns, 26.9071 us/op
+WorkloadActual   3: 4096 op, 121348205.00 ns, 29.6260 us/op
+WorkloadActual   4: 4096 op, 102082846.00 ns, 24.9226 us/op
+WorkloadActual   5: 4096 op, 95285230.00 ns, 23.2630 us/op
+WorkloadActual   6: 4096 op, 103640212.00 ns, 25.3028 us/op
+WorkloadActual   7: 4096 op, 108654086.00 ns, 26.5269 us/op
+WorkloadActual   8: 4096 op, 109343643.00 ns, 26.6952 us/op
+WorkloadActual   9: 4096 op, 104098486.00 ns, 25.4147 us/op
+WorkloadActual  10: 4096 op, 154023855.00 ns, 37.6035 us/op
+WorkloadActual  11: 4096 op, 139458277.00 ns, 34.0474 us/op
+WorkloadActual  12: 4096 op, 101446063.00 ns, 24.7671 us/op
+WorkloadActual  13: 4096 op, 109682666.00 ns, 26.7780 us/op
+WorkloadActual  14: 4096 op, 143339818.00 ns, 34.9951 us/op
+WorkloadActual  15: 4096 op, 150017875.00 ns, 36.6255 us/op
+WorkloadActual  16: 4096 op, 188019916.00 ns, 45.9033 us/op
+WorkloadActual  17: 4096 op, 157979785.00 ns, 38.5693 us/op
+WorkloadActual  18: 4096 op, 98772592.00 ns, 24.1144 us/op
+WorkloadActual  19: 4096 op, 102528362.00 ns, 25.0313 us/op
+WorkloadActual  20: 4096 op, 102669353.00 ns, 25.0658 us/op
+WorkloadActual  21: 4096 op, 103475653.00 ns, 25.2626 us/op
+WorkloadActual  22: 4096 op, 136832075.00 ns, 33.4063 us/op
+WorkloadActual  23: 4096 op, 121846393.00 ns, 29.7477 us/op
+WorkloadActual  24: 4096 op, 122324802.00 ns, 29.8645 us/op
+WorkloadActual  25: 4096 op, 109372925.00 ns, 26.7024 us/op
+WorkloadActual  26: 4096 op, 105308881.00 ns, 25.7102 us/op
+WorkloadActual  27: 4096 op, 141807309.00 ns, 34.6209 us/op
+WorkloadActual  28: 4096 op, 123036065.00 ns, 30.0381 us/op
+WorkloadActual  29: 4096 op, 100586488.00 ns, 24.5572 us/op
+WorkloadActual  30: 4096 op, 134935552.00 ns, 32.9432 us/op
+WorkloadActual  31: 4096 op, 138881812.00 ns, 33.9067 us/op
+WorkloadActual  32: 4096 op, 109159796.00 ns, 26.6503 us/op
+WorkloadActual  33: 4096 op, 138139759.00 ns, 33.7255 us/op
+WorkloadActual  34: 4096 op, 173252834.00 ns, 42.2981 us/op
+WorkloadActual  35: 4096 op, 183516518.00 ns, 44.8038 us/op
+WorkloadActual  36: 4096 op, 190131483.00 ns, 46.4188 us/op
+WorkloadActual  37: 4096 op, 113222127.00 ns, 27.6421 us/op
+WorkloadActual  38: 4096 op, 102844495.00 ns, 25.1085 us/op
+WorkloadActual  39: 4096 op, 106264759.00 ns, 25.9435 us/op
+WorkloadActual  40: 4096 op, 120733333.00 ns, 29.4759 us/op
+WorkloadActual  41: 4096 op, 125764767.00 ns, 30.7043 us/op
+WorkloadActual  42: 4096 op, 111916408.00 ns, 27.3233 us/op
+WorkloadActual  43: 4096 op, 104496217.00 ns, 25.5118 us/op
+WorkloadActual  44: 4096 op, 152804712.00 ns, 37.3058 us/op
+WorkloadActual  45: 4096 op, 103177989.00 ns, 25.1899 us/op
+WorkloadActual  46: 4096 op, 107721806.00 ns, 26.2993 us/op
+WorkloadActual  47: 4096 op, 111624531.00 ns, 27.2521 us/op
+WorkloadActual  48: 4096 op, 117073247.00 ns, 28.5823 us/op
+WorkloadActual  49: 4096 op, 107459786.00 ns, 26.2353 us/op
+WorkloadActual  50: 4096 op, 115536186.00 ns, 28.2071 us/op
+WorkloadActual  51: 4096 op, 121894859.00 ns, 29.7595 us/op
+WorkloadActual  52: 4096 op, 144214767.00 ns, 35.2087 us/op
+WorkloadActual  53: 4096 op, 118967069.00 ns, 29.0447 us/op
+WorkloadActual  54: 4096 op, 120654764.00 ns, 29.4567 us/op
+WorkloadActual  55: 4096 op, 122387675.00 ns, 29.8798 us/op
+WorkloadActual  56: 4096 op, 122300184.00 ns, 29.8584 us/op
+WorkloadActual  57: 4096 op, 114368290.00 ns, 27.9219 us/op
+WorkloadActual  58: 4096 op, 145797717.00 ns, 35.5951 us/op
+WorkloadActual  59: 4096 op, 167235937.00 ns, 40.8291 us/op
+WorkloadActual  60: 4096 op, 128888452.00 ns, 31.4669 us/op
+WorkloadActual  61: 4096 op, 127121871.00 ns, 31.0356 us/op
+WorkloadActual  62: 4096 op, 136625787.00 ns, 33.3559 us/op
+WorkloadActual  63: 4096 op, 122521404.00 ns, 29.9125 us/op
+WorkloadActual  64: 4096 op, 162994157.00 ns, 39.7935 us/op
+WorkloadActual  65: 4096 op, 138943706.00 ns, 33.9218 us/op
+WorkloadActual  66: 4096 op, 134655931.00 ns, 32.8750 us/op
+WorkloadActual  67: 4096 op, 163488993.00 ns, 39.9143 us/op
+WorkloadActual  68: 4096 op, 162624493.00 ns, 39.7032 us/op
+WorkloadActual  69: 4096 op, 179373422.00 ns, 43.7923 us/op
+WorkloadActual  70: 4096 op, 128413808.00 ns, 31.3510 us/op
+WorkloadActual  71: 4096 op, 103831744.00 ns, 25.3495 us/op
+WorkloadActual  72: 4096 op, 150167523.00 ns, 36.6620 us/op
+WorkloadActual  73: 4096 op, 120904204.00 ns, 29.5176 us/op
+WorkloadActual  74: 4096 op, 118411960.00 ns, 28.9092 us/op
+WorkloadActual  75: 4096 op, 104459892.00 ns, 25.5029 us/op
+WorkloadActual  76: 4096 op, 115446903.00 ns, 28.1853 us/op
+WorkloadActual  77: 4096 op, 106632111.00 ns, 26.0332 us/op
+WorkloadActual  78: 4096 op, 112739227.00 ns, 27.5242 us/op
+WorkloadActual  79: 4096 op, 105518025.00 ns, 25.7612 us/op
+WorkloadActual  80: 4096 op, 118067846.00 ns, 28.8252 us/op
+WorkloadActual  81: 4096 op, 132590500.00 ns, 32.3707 us/op
+WorkloadActual  82: 4096 op, 106238204.00 ns, 25.9371 us/op
+WorkloadActual  83: 4096 op, 106881780.00 ns, 26.0942 us/op
+WorkloadActual  84: 4096 op, 110202594.00 ns, 26.9049 us/op
+WorkloadActual  85: 4096 op, 114186162.00 ns, 27.8775 us/op
+WorkloadActual  86: 4096 op, 118441238.00 ns, 28.9163 us/op
+WorkloadActual  87: 4096 op, 125001543.00 ns, 30.5180 us/op
+WorkloadActual  88: 4096 op, 123838904.00 ns, 30.2341 us/op
+WorkloadActual  89: 4096 op, 118161609.00 ns, 28.8480 us/op
+WorkloadActual  90: 4096 op, 106426256.00 ns, 25.9830 us/op
+WorkloadActual  91: 4096 op, 120206794.00 ns, 29.3474 us/op
+WorkloadActual  92: 4096 op, 125973053.00 ns, 30.7551 us/op
+WorkloadActual  93: 4096 op, 190258970.00 ns, 46.4499 us/op
+WorkloadActual  94: 4096 op, 190679612.00 ns, 46.5526 us/op
+WorkloadActual  95: 4096 op, 187837033.00 ns, 45.8587 us/op
+WorkloadActual  96: 4096 op, 129702831.00 ns, 31.6657 us/op
+WorkloadActual  97: 4096 op, 117011271.00 ns, 28.5672 us/op
+WorkloadActual  98: 4096 op, 106376304.00 ns, 25.9708 us/op
+WorkloadActual  99: 4096 op, 109864414.00 ns, 26.8224 us/op
+WorkloadActual  100: 4096 op, 115038832.00 ns, 28.0857 us/op
+
+// AfterActualRun
+WorkloadResult   1: 4096 op, 125093902.00 ns, 30.5405 us/op
+WorkloadResult   2: 4096 op, 110002624.00 ns, 26.8561 us/op
+WorkloadResult   3: 4096 op, 121139488.00 ns, 29.5751 us/op
+WorkloadResult   4: 4096 op, 101874129.00 ns, 24.8716 us/op
+WorkloadResult   5: 4096 op, 95076513.00 ns, 23.2120 us/op
+WorkloadResult   6: 4096 op, 103431495.00 ns, 25.2518 us/op
+WorkloadResult   7: 4096 op, 108445369.00 ns, 26.4759 us/op
+WorkloadResult   8: 4096 op, 109134926.00 ns, 26.6443 us/op
+WorkloadResult   9: 4096 op, 103889769.00 ns, 25.3637 us/op
+WorkloadResult  10: 4096 op, 153815138.00 ns, 37.5525 us/op
+WorkloadResult  11: 4096 op, 139249560.00 ns, 33.9965 us/op
+WorkloadResult  12: 4096 op, 101237346.00 ns, 24.7161 us/op
+WorkloadResult  13: 4096 op, 109473949.00 ns, 26.7270 us/op
+WorkloadResult  14: 4096 op, 143131101.00 ns, 34.9441 us/op
+WorkloadResult  15: 4096 op, 149809158.00 ns, 36.5745 us/op
+WorkloadResult  16: 4096 op, 157771068.00 ns, 38.5183 us/op
+WorkloadResult  17: 4096 op, 98563875.00 ns, 24.0634 us/op
+WorkloadResult  18: 4096 op, 102319645.00 ns, 24.9804 us/op
+WorkloadResult  19: 4096 op, 102460636.00 ns, 25.0148 us/op
+WorkloadResult  20: 4096 op, 103266936.00 ns, 25.2117 us/op
+WorkloadResult  21: 4096 op, 136623358.00 ns, 33.3553 us/op
+WorkloadResult  22: 4096 op, 121637676.00 ns, 29.6967 us/op
+WorkloadResult  23: 4096 op, 122116085.00 ns, 29.8135 us/op
+WorkloadResult  24: 4096 op, 109164208.00 ns, 26.6514 us/op
+WorkloadResult  25: 4096 op, 105100164.00 ns, 25.6592 us/op
+WorkloadResult  26: 4096 op, 141598592.00 ns, 34.5700 us/op
+WorkloadResult  27: 4096 op, 122827348.00 ns, 29.9871 us/op
+WorkloadResult  28: 4096 op, 100377771.00 ns, 24.5063 us/op
+WorkloadResult  29: 4096 op, 134726835.00 ns, 32.8923 us/op
+WorkloadResult  30: 4096 op, 138673095.00 ns, 33.8557 us/op
+WorkloadResult  31: 4096 op, 108951079.00 ns, 26.5994 us/op
+WorkloadResult  32: 4096 op, 137931042.00 ns, 33.6746 us/op
+WorkloadResult  33: 4096 op, 173044117.00 ns, 42.2471 us/op
+WorkloadResult  34: 4096 op, 113013410.00 ns, 27.5912 us/op
+WorkloadResult  35: 4096 op, 102635778.00 ns, 25.0576 us/op
+WorkloadResult  36: 4096 op, 106056042.00 ns, 25.8926 us/op
+WorkloadResult  37: 4096 op, 120524616.00 ns, 29.4250 us/op
+WorkloadResult  38: 4096 op, 125556050.00 ns, 30.6533 us/op
+WorkloadResult  39: 4096 op, 111707691.00 ns, 27.2724 us/op
+WorkloadResult  40: 4096 op, 104287500.00 ns, 25.4608 us/op
+WorkloadResult  41: 4096 op, 152595995.00 ns, 37.2549 us/op
+WorkloadResult  42: 4096 op, 102969272.00 ns, 25.1390 us/op
+WorkloadResult  43: 4096 op, 107513089.00 ns, 26.2483 us/op
+WorkloadResult  44: 4096 op, 111415814.00 ns, 27.2011 us/op
+WorkloadResult  45: 4096 op, 116864530.00 ns, 28.5314 us/op
+WorkloadResult  46: 4096 op, 107251069.00 ns, 26.1843 us/op
+WorkloadResult  47: 4096 op, 115327469.00 ns, 28.1561 us/op
+WorkloadResult  48: 4096 op, 121686142.00 ns, 29.7085 us/op
+WorkloadResult  49: 4096 op, 144006050.00 ns, 35.1577 us/op
+WorkloadResult  50: 4096 op, 118758352.00 ns, 28.9937 us/op
+WorkloadResult  51: 4096 op, 120446047.00 ns, 29.4058 us/op
+WorkloadResult  52: 4096 op, 122178958.00 ns, 29.8288 us/op
+WorkloadResult  53: 4096 op, 122091467.00 ns, 29.8075 us/op
+WorkloadResult  54: 4096 op, 114159573.00 ns, 27.8710 us/op
+WorkloadResult  55: 4096 op, 145589000.00 ns, 35.5442 us/op
+WorkloadResult  56: 4096 op, 167027220.00 ns, 40.7781 us/op
+WorkloadResult  57: 4096 op, 128679735.00 ns, 31.4160 us/op
+WorkloadResult  58: 4096 op, 126913154.00 ns, 30.9847 us/op
+WorkloadResult  59: 4096 op, 136417070.00 ns, 33.3049 us/op
+WorkloadResult  60: 4096 op, 122312687.00 ns, 29.8615 us/op
+WorkloadResult  61: 4096 op, 162785440.00 ns, 39.7425 us/op
+WorkloadResult  62: 4096 op, 138734989.00 ns, 33.8708 us/op
+WorkloadResult  63: 4096 op, 134447214.00 ns, 32.8240 us/op
+WorkloadResult  64: 4096 op, 163280276.00 ns, 39.8633 us/op
+WorkloadResult  65: 4096 op, 162415776.00 ns, 39.6523 us/op
+WorkloadResult  66: 4096 op, 179164705.00 ns, 43.7414 us/op
+WorkloadResult  67: 4096 op, 128205091.00 ns, 31.3001 us/op
+WorkloadResult  68: 4096 op, 103623027.00 ns, 25.2986 us/op
+WorkloadResult  69: 4096 op, 149958806.00 ns, 36.6110 us/op
+WorkloadResult  70: 4096 op, 120695487.00 ns, 29.4667 us/op
+WorkloadResult  71: 4096 op, 118203243.00 ns, 28.8582 us/op
+WorkloadResult  72: 4096 op, 104251175.00 ns, 25.4519 us/op
+WorkloadResult  73: 4096 op, 115238186.00 ns, 28.1343 us/op
+WorkloadResult  74: 4096 op, 106423394.00 ns, 25.9823 us/op
+WorkloadResult  75: 4096 op, 112530510.00 ns, 27.4733 us/op
+WorkloadResult  76: 4096 op, 105309308.00 ns, 25.7103 us/op
+WorkloadResult  77: 4096 op, 117859129.00 ns, 28.7742 us/op
+WorkloadResult  78: 4096 op, 132381783.00 ns, 32.3198 us/op
+WorkloadResult  79: 4096 op, 106029487.00 ns, 25.8861 us/op
+WorkloadResult  80: 4096 op, 106673063.00 ns, 26.0432 us/op
+WorkloadResult  81: 4096 op, 109993877.00 ns, 26.8540 us/op
+WorkloadResult  82: 4096 op, 113977445.00 ns, 27.8265 us/op
+WorkloadResult  83: 4096 op, 118232521.00 ns, 28.8654 us/op
+WorkloadResult  84: 4096 op, 124792826.00 ns, 30.4670 us/op
+WorkloadResult  85: 4096 op, 123630187.00 ns, 30.1832 us/op
+WorkloadResult  86: 4096 op, 117952892.00 ns, 28.7971 us/op
+WorkloadResult  87: 4096 op, 106217539.00 ns, 25.9320 us/op
+WorkloadResult  88: 4096 op, 119998077.00 ns, 29.2964 us/op
+WorkloadResult  89: 4096 op, 125764336.00 ns, 30.7042 us/op
+WorkloadResult  90: 4096 op, 129494114.00 ns, 31.6148 us/op
+WorkloadResult  91: 4096 op, 116802554.00 ns, 28.5162 us/op
+WorkloadResult  92: 4096 op, 106167587.00 ns, 25.9198 us/op
+WorkloadResult  93: 4096 op, 109655697.00 ns, 26.7714 us/op
+WorkloadResult  94: 4096 op, 114830115.00 ns, 28.0347 us/op
+GC:  4 0 0 41648800 4096
+Threading:  0 0 4096
+
+// AfterAll
+// Benchmark Process 1257133 has exited with code 0.
+
+Mean = 29.831 us, StdErr = 0.470 us (1.57%), N = 94, StdDev = 4.553 us
+Min = 23.212 us, Q1 = 26.200 us, Median = 28.862 us, Q3 = 32.144 us, Max = 43.741 us
+IQR = 5.943 us, LowerFence = 17.286 us, UpperFence = 41.058 us
+ConfidenceInterval = [28.235 us; 31.427 us] (CI 99.9%), Margin = 1.596 us (5.35% of Mean)
+Skewness = 1.04, Kurtosis = 3.43, MValue = 3.74
+
+// **************************
+// Benchmark: CountBenchmarks.Array: DefaultJob [N=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.Array(N: 1000)" --job "Default" --benchmarkId 6 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 1663224.00 ns, 1.6632 ms/op
+WorkloadJitting  1: 1 op, 20117965.00 ns, 20.1180 ms/op
+
+OverheadJitting  2: 16 op, 3276400.00 ns, 204.7750 us/op
+WorkloadJitting  2: 16 op, 40408669.00 ns, 2.5255 ms/op
+
+WorkloadPilot    1: 16 op, 32133492.00 ns, 2.0083 ms/op
+WorkloadPilot    2: 32 op, 71996712.00 ns, 2.2499 ms/op
+WorkloadPilot    3: 64 op, 153197606.00 ns, 2.3937 ms/op
+WorkloadPilot    4: 128 op, 365186373.00 ns, 2.8530 ms/op
+WorkloadPilot    5: 256 op, 716701502.00 ns, 2.7996 ms/op
+
+OverheadWarmup   1: 256 op, 23369.00 ns, 91.2852 ns/op
+OverheadWarmup   2: 256 op, 23246.00 ns, 90.8047 ns/op
+OverheadWarmup   3: 256 op, 22843.00 ns, 89.2305 ns/op
+OverheadWarmup   4: 256 op, 15310.00 ns, 59.8047 ns/op
+OverheadWarmup   5: 256 op, 16678.00 ns, 65.1484 ns/op
+OverheadWarmup   6: 256 op, 14879.00 ns, 58.1211 ns/op
+OverheadWarmup   7: 256 op, 22747.00 ns, 88.8555 ns/op
+OverheadWarmup   8: 256 op, 16498.00 ns, 64.4453 ns/op
+
+OverheadActual   1: 256 op, 21059.00 ns, 82.2617 ns/op
+OverheadActual   2: 256 op, 22877.00 ns, 89.3633 ns/op
+OverheadActual   3: 256 op, 17524.00 ns, 68.4531 ns/op
+OverheadActual   4: 256 op, 20582.00 ns, 80.3984 ns/op
+OverheadActual   5: 256 op, 24260.00 ns, 94.7656 ns/op
+OverheadActual   6: 256 op, 21990.00 ns, 85.8984 ns/op
+OverheadActual   7: 256 op, 23417.00 ns, 91.4727 ns/op
+OverheadActual   8: 256 op, 20600.00 ns, 80.4688 ns/op
+OverheadActual   9: 256 op, 21895.00 ns, 85.5273 ns/op
+OverheadActual  10: 256 op, 16263.00 ns, 63.5273 ns/op
+OverheadActual  11: 256 op, 14993.00 ns, 58.5664 ns/op
+OverheadActual  12: 256 op, 14351.00 ns, 56.0586 ns/op
+OverheadActual  13: 256 op, 14120.00 ns, 55.1562 ns/op
+OverheadActual  14: 256 op, 19939.00 ns, 77.8867 ns/op
+OverheadActual  15: 256 op, 12484.00 ns, 48.7656 ns/op
+OverheadActual  16: 256 op, 18553.00 ns, 72.4727 ns/op
+OverheadActual  17: 256 op, 13620.00 ns, 53.2031 ns/op
+OverheadActual  18: 256 op, 14711.00 ns, 57.4648 ns/op
+OverheadActual  19: 256 op, 13716.00 ns, 53.5781 ns/op
+OverheadActual  20: 256 op, 13456.00 ns, 52.5625 ns/op
+
+WorkloadWarmup   1: 256 op, 636827236.00 ns, 2.4876 ms/op
+WorkloadWarmup   2: 256 op, 660727902.00 ns, 2.5810 ms/op
+WorkloadWarmup   3: 256 op, 653689763.00 ns, 2.5535 ms/op
+WorkloadWarmup   4: 256 op, 263963851.00 ns, 1.0311 ms/op
+WorkloadWarmup   5: 256 op, 166035090.00 ns, 648.5746 us/op
+WorkloadWarmup   6: 256 op, 118444943.00 ns, 462.6756 us/op
+WorkloadWarmup   7: 256 op, 82088927.00 ns, 320.6599 us/op
+WorkloadWarmup   8: 256 op, 91218928.00 ns, 356.3239 us/op
+WorkloadWarmup   9: 256 op, 100997053.00 ns, 394.5197 us/op
+WorkloadWarmup  10: 256 op, 86848081.00 ns, 339.2503 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 256 op, 98567432.00 ns, 385.0290 us/op
+WorkloadActual   2: 256 op, 69521441.00 ns, 271.5681 us/op
+WorkloadActual   3: 256 op, 71838166.00 ns, 280.6178 us/op
+WorkloadActual   4: 256 op, 62100289.00 ns, 242.5793 us/op
+WorkloadActual   5: 256 op, 85517537.00 ns, 334.0529 us/op
+WorkloadActual   6: 256 op, 71582868.00 ns, 279.6206 us/op
+WorkloadActual   7: 256 op, 68362632.00 ns, 267.0415 us/op
+WorkloadActual   8: 256 op, 70399217.00 ns, 274.9969 us/op
+WorkloadActual   9: 256 op, 64842094.00 ns, 253.2894 us/op
+WorkloadActual  10: 256 op, 91217392.00 ns, 356.3179 us/op
+WorkloadActual  11: 256 op, 86543704.00 ns, 338.0613 us/op
+WorkloadActual  12: 256 op, 70784069.00 ns, 276.5003 us/op
+WorkloadActual  13: 256 op, 94220818.00 ns, 368.0501 us/op
+WorkloadActual  14: 256 op, 94773094.00 ns, 370.2074 us/op
+WorkloadActual  15: 256 op, 69470477.00 ns, 271.3691 us/op
+WorkloadActual  16: 256 op, 66987396.00 ns, 261.6695 us/op
+WorkloadActual  17: 256 op, 64611136.00 ns, 252.3872 us/op
+WorkloadActual  18: 256 op, 88861821.00 ns, 347.1165 us/op
+WorkloadActual  19: 256 op, 110048311.00 ns, 429.8762 us/op
+WorkloadActual  20: 256 op, 110708743.00 ns, 432.4560 us/op
+WorkloadActual  21: 256 op, 84949828.00 ns, 331.8353 us/op
+WorkloadActual  22: 256 op, 75718138.00 ns, 295.7740 us/op
+WorkloadActual  23: 256 op, 66983278.00 ns, 261.6534 us/op
+WorkloadActual  24: 256 op, 67856206.00 ns, 265.0633 us/op
+WorkloadActual  25: 256 op, 79294991.00 ns, 309.7461 us/op
+WorkloadActual  26: 256 op, 74198296.00 ns, 289.8371 us/op
+WorkloadActual  27: 256 op, 68974579.00 ns, 269.4319 us/op
+WorkloadActual  28: 256 op, 62654750.00 ns, 244.7451 us/op
+WorkloadActual  29: 256 op, 75697284.00 ns, 295.6925 us/op
+WorkloadActual  30: 256 op, 106220364.00 ns, 414.9233 us/op
+WorkloadActual  31: 256 op, 70477696.00 ns, 275.3035 us/op
+WorkloadActual  32: 256 op, 75245163.00 ns, 293.9264 us/op
+WorkloadActual  33: 256 op, 74478610.00 ns, 290.9321 us/op
+WorkloadActual  34: 256 op, 86472820.00 ns, 337.7845 us/op
+WorkloadActual  35: 256 op, 82111172.00 ns, 320.7468 us/op
+WorkloadActual  36: 256 op, 67683354.00 ns, 264.3881 us/op
+WorkloadActual  37: 256 op, 60022403.00 ns, 234.4625 us/op
+WorkloadActual  38: 256 op, 81055576.00 ns, 316.6233 us/op
+WorkloadActual  39: 256 op, 71690530.00 ns, 280.0411 us/op
+WorkloadActual  40: 256 op, 66167883.00 ns, 258.4683 us/op
+WorkloadActual  41: 256 op, 71382871.00 ns, 278.8393 us/op
+WorkloadActual  42: 256 op, 96839662.00 ns, 378.2799 us/op
+WorkloadActual  43: 256 op, 94159650.00 ns, 367.8111 us/op
+WorkloadActual  44: 256 op, 168508984.00 ns, 658.2382 us/op
+WorkloadActual  45: 256 op, 104992940.00 ns, 410.1287 us/op
+WorkloadActual  46: 256 op, 104860308.00 ns, 409.6106 us/op
+WorkloadActual  47: 256 op, 110223795.00 ns, 430.5617 us/op
+WorkloadActual  48: 256 op, 109259360.00 ns, 426.7944 us/op
+WorkloadActual  49: 256 op, 76993224.00 ns, 300.7548 us/op
+WorkloadActual  50: 256 op, 78113413.00 ns, 305.1305 us/op
+WorkloadActual  51: 256 op, 102493084.00 ns, 400.3636 us/op
+WorkloadActual  52: 256 op, 77662078.00 ns, 303.3675 us/op
+WorkloadActual  53: 256 op, 68869917.00 ns, 269.0231 us/op
+WorkloadActual  54: 256 op, 69888432.00 ns, 273.0017 us/op
+WorkloadActual  55: 256 op, 64237362.00 ns, 250.9272 us/op
+WorkloadActual  56: 256 op, 74207929.00 ns, 289.8747 us/op
+WorkloadActual  57: 256 op, 85062732.00 ns, 332.2763 us/op
+WorkloadActual  58: 256 op, 73849335.00 ns, 288.4740 us/op
+WorkloadActual  59: 256 op, 109339064.00 ns, 427.1057 us/op
+WorkloadActual  60: 256 op, 93145599.00 ns, 363.8500 us/op
+WorkloadActual  61: 256 op, 95480141.00 ns, 372.9693 us/op
+WorkloadActual  62: 256 op, 94104338.00 ns, 367.5951 us/op
+WorkloadActual  63: 256 op, 148669628.00 ns, 580.7407 us/op
+WorkloadActual  64: 256 op, 92644922.00 ns, 361.8942 us/op
+WorkloadActual  65: 256 op, 63021914.00 ns, 246.1794 us/op
+WorkloadActual  66: 256 op, 85590274.00 ns, 334.3370 us/op
+WorkloadActual  67: 256 op, 66573690.00 ns, 260.0535 us/op
+WorkloadActual  68: 256 op, 68487526.00 ns, 267.5294 us/op
+WorkloadActual  69: 256 op, 63267909.00 ns, 247.1403 us/op
+WorkloadActual  70: 256 op, 63041931.00 ns, 246.2575 us/op
+WorkloadActual  71: 256 op, 59827973.00 ns, 233.7030 us/op
+WorkloadActual  72: 256 op, 70567992.00 ns, 275.6562 us/op
+WorkloadActual  73: 256 op, 70643507.00 ns, 275.9512 us/op
+WorkloadActual  74: 256 op, 136435942.00 ns, 532.9529 us/op
+WorkloadActual  75: 256 op, 100549779.00 ns, 392.7726 us/op
+WorkloadActual  76: 256 op, 112330671.00 ns, 438.7917 us/op
+WorkloadActual  77: 256 op, 96855654.00 ns, 378.3424 us/op
+WorkloadActual  78: 256 op, 61086563.00 ns, 238.6194 us/op
+WorkloadActual  79: 256 op, 60378942.00 ns, 235.8552 us/op
+WorkloadActual  80: 256 op, 55660553.00 ns, 217.4240 us/op
+WorkloadActual  81: 256 op, 51462538.00 ns, 201.0255 us/op
+WorkloadActual  82: 256 op, 64120250.00 ns, 250.4697 us/op
+WorkloadActual  83: 256 op, 66012435.00 ns, 257.8611 us/op
+WorkloadActual  84: 256 op, 58236127.00 ns, 227.4849 us/op
+WorkloadActual  85: 256 op, 57801845.00 ns, 225.7885 us/op
+WorkloadActual  86: 256 op, 63624688.00 ns, 248.5339 us/op
+WorkloadActual  87: 256 op, 88869543.00 ns, 347.1467 us/op
+WorkloadActual  88: 256 op, 59451403.00 ns, 232.2320 us/op
+WorkloadActual  89: 256 op, 64363308.00 ns, 251.4192 us/op
+WorkloadActual  90: 256 op, 71260088.00 ns, 278.3597 us/op
+WorkloadActual  91: 256 op, 81097840.00 ns, 316.7884 us/op
+WorkloadActual  92: 256 op, 74294328.00 ns, 290.2122 us/op
+WorkloadActual  93: 256 op, 63302167.00 ns, 247.2741 us/op
+WorkloadActual  94: 256 op, 79293684.00 ns, 309.7410 us/op
+WorkloadActual  95: 256 op, 68854906.00 ns, 268.9645 us/op
+WorkloadActual  96: 256 op, 54567610.00 ns, 213.1547 us/op
+WorkloadActual  97: 256 op, 61922886.00 ns, 241.8863 us/op
+WorkloadActual  98: 256 op, 98263690.00 ns, 383.8425 us/op
+WorkloadActual  99: 256 op, 80698848.00 ns, 315.2299 us/op
+WorkloadActual  100: 256 op, 63725361.00 ns, 248.9272 us/op
+
+// AfterActualRun
+WorkloadResult   1: 256 op, 98549393.50 ns, 384.9586 us/op
+WorkloadResult   2: 256 op, 69503402.50 ns, 271.4977 us/op
+WorkloadResult   3: 256 op, 71820127.50 ns, 280.5474 us/op
+WorkloadResult   4: 256 op, 62082250.50 ns, 242.5088 us/op
+WorkloadResult   5: 256 op, 85499498.50 ns, 333.9824 us/op
+WorkloadResult   6: 256 op, 71564829.50 ns, 279.5501 us/op
+WorkloadResult   7: 256 op, 68344593.50 ns, 266.9711 us/op
+WorkloadResult   8: 256 op, 70381178.50 ns, 274.9265 us/op
+WorkloadResult   9: 256 op, 64824055.50 ns, 253.2190 us/op
+WorkloadResult  10: 256 op, 91199353.50 ns, 356.2475 us/op
+WorkloadResult  11: 256 op, 86525665.50 ns, 337.9909 us/op
+WorkloadResult  12: 256 op, 70766030.50 ns, 276.4298 us/op
+WorkloadResult  13: 256 op, 94202779.50 ns, 367.9796 us/op
+WorkloadResult  14: 256 op, 94755055.50 ns, 370.1369 us/op
+WorkloadResult  15: 256 op, 69452438.50 ns, 271.2986 us/op
+WorkloadResult  16: 256 op, 66969357.50 ns, 261.5991 us/op
+WorkloadResult  17: 256 op, 64593097.50 ns, 252.3168 us/op
+WorkloadResult  18: 256 op, 88843782.50 ns, 347.0460 us/op
+WorkloadResult  19: 256 op, 110030272.50 ns, 429.8058 us/op
+WorkloadResult  20: 256 op, 110690704.50 ns, 432.3856 us/op
+WorkloadResult  21: 256 op, 84931789.50 ns, 331.7648 us/op
+WorkloadResult  22: 256 op, 75700099.50 ns, 295.7035 us/op
+WorkloadResult  23: 256 op, 66965239.50 ns, 261.5830 us/op
+WorkloadResult  24: 256 op, 67838167.50 ns, 264.9928 us/op
+WorkloadResult  25: 256 op, 79276952.50 ns, 309.6756 us/op
+WorkloadResult  26: 256 op, 74180257.50 ns, 289.7666 us/op
+WorkloadResult  27: 256 op, 68956540.50 ns, 269.3615 us/op
+WorkloadResult  28: 256 op, 62636711.50 ns, 244.6747 us/op
+WorkloadResult  29: 256 op, 75679245.50 ns, 295.6221 us/op
+WorkloadResult  30: 256 op, 106202325.50 ns, 414.8528 us/op
+WorkloadResult  31: 256 op, 70459657.50 ns, 275.2330 us/op
+WorkloadResult  32: 256 op, 75227124.50 ns, 293.8560 us/op
+WorkloadResult  33: 256 op, 74460571.50 ns, 290.8616 us/op
+WorkloadResult  34: 256 op, 86454781.50 ns, 337.7140 us/op
+WorkloadResult  35: 256 op, 82093133.50 ns, 320.6763 us/op
+WorkloadResult  36: 256 op, 67665315.50 ns, 264.3176 us/op
+WorkloadResult  37: 256 op, 60004364.50 ns, 234.3920 us/op
+WorkloadResult  38: 256 op, 81037537.50 ns, 316.5529 us/op
+WorkloadResult  39: 256 op, 71672491.50 ns, 279.9707 us/op
+WorkloadResult  40: 256 op, 66149844.50 ns, 258.3978 us/op
+WorkloadResult  41: 256 op, 71364832.50 ns, 278.7689 us/op
+WorkloadResult  42: 256 op, 96821623.50 ns, 378.2095 us/op
+WorkloadResult  43: 256 op, 94141611.50 ns, 367.7407 us/op
+WorkloadResult  44: 256 op, 104974901.50 ns, 410.0582 us/op
+WorkloadResult  45: 256 op, 104842269.50 ns, 409.5401 us/op
+WorkloadResult  46: 256 op, 110205756.50 ns, 430.4912 us/op
+WorkloadResult  47: 256 op, 109241321.50 ns, 426.7239 us/op
+WorkloadResult  48: 256 op, 76975185.50 ns, 300.6843 us/op
+WorkloadResult  49: 256 op, 78095374.50 ns, 305.0601 us/op
+WorkloadResult  50: 256 op, 102475045.50 ns, 400.2931 us/op
+WorkloadResult  51: 256 op, 77644039.50 ns, 303.2970 us/op
+WorkloadResult  52: 256 op, 68851878.50 ns, 268.9527 us/op
+WorkloadResult  53: 256 op, 69870393.50 ns, 272.9312 us/op
+WorkloadResult  54: 256 op, 64219323.50 ns, 250.8567 us/op
+WorkloadResult  55: 256 op, 74189890.50 ns, 289.8043 us/op
+WorkloadResult  56: 256 op, 85044693.50 ns, 332.2058 us/op
+WorkloadResult  57: 256 op, 73831296.50 ns, 288.4035 us/op
+WorkloadResult  58: 256 op, 109321025.50 ns, 427.0353 us/op
+WorkloadResult  59: 256 op, 93127560.50 ns, 363.7795 us/op
+WorkloadResult  60: 256 op, 95462102.50 ns, 372.8988 us/op
+WorkloadResult  61: 256 op, 94086299.50 ns, 367.5246 us/op
+WorkloadResult  62: 256 op, 92626883.50 ns, 361.8238 us/op
+WorkloadResult  63: 256 op, 63003875.50 ns, 246.1089 us/op
+WorkloadResult  64: 256 op, 85572235.50 ns, 334.2665 us/op
+WorkloadResult  65: 256 op, 66555651.50 ns, 259.9830 us/op
+WorkloadResult  66: 256 op, 68469487.50 ns, 267.4589 us/op
+WorkloadResult  67: 256 op, 63249870.50 ns, 247.0698 us/op
+WorkloadResult  68: 256 op, 63023892.50 ns, 246.1871 us/op
+WorkloadResult  69: 256 op, 59809934.50 ns, 233.6326 us/op
+WorkloadResult  70: 256 op, 70549953.50 ns, 275.5858 us/op
+WorkloadResult  71: 256 op, 70625468.50 ns, 275.8807 us/op
+WorkloadResult  72: 256 op, 100531740.50 ns, 392.7021 us/op
+WorkloadResult  73: 256 op, 112312632.50 ns, 438.7212 us/op
+WorkloadResult  74: 256 op, 96837615.50 ns, 378.2719 us/op
+WorkloadResult  75: 256 op, 61068524.50 ns, 238.5489 us/op
+WorkloadResult  76: 256 op, 60360903.50 ns, 235.7848 us/op
+WorkloadResult  77: 256 op, 55642514.50 ns, 217.3536 us/op
+WorkloadResult  78: 256 op, 51444499.50 ns, 200.9551 us/op
+WorkloadResult  79: 256 op, 64102211.50 ns, 250.3993 us/op
+WorkloadResult  80: 256 op, 65994396.50 ns, 257.7906 us/op
+WorkloadResult  81: 256 op, 58218088.50 ns, 227.4144 us/op
+WorkloadResult  82: 256 op, 57783806.50 ns, 225.7180 us/op
+WorkloadResult  83: 256 op, 63606649.50 ns, 248.4635 us/op
+WorkloadResult  84: 256 op, 88851504.50 ns, 347.0762 us/op
+WorkloadResult  85: 256 op, 59433364.50 ns, 232.1616 us/op
+WorkloadResult  86: 256 op, 64345269.50 ns, 251.3487 us/op
+WorkloadResult  87: 256 op, 71242049.50 ns, 278.2893 us/op
+WorkloadResult  88: 256 op, 81079801.50 ns, 316.7180 us/op
+WorkloadResult  89: 256 op, 74276289.50 ns, 290.1418 us/op
+WorkloadResult  90: 256 op, 63284128.50 ns, 247.2036 us/op
+WorkloadResult  91: 256 op, 79275645.50 ns, 309.6705 us/op
+WorkloadResult  92: 256 op, 68836867.50 ns, 268.8940 us/op
+WorkloadResult  93: 256 op, 54549571.50 ns, 213.0843 us/op
+WorkloadResult  94: 256 op, 61904847.50 ns, 241.8158 us/op
+WorkloadResult  95: 256 op, 98245651.50 ns, 383.7721 us/op
+WorkloadResult  96: 256 op, 80680809.50 ns, 315.1594 us/op
+WorkloadResult  97: 256 op, 63707322.50 ns, 248.8567 us/op
+GC:  2 0 0 24715264 256
+Threading:  0 0 256
+
+// AfterAll
+// Benchmark Process 1257183 has exited with code 0.
+
+Mean = 302.999 us, StdErr = 6.135 us (2.02%), N = 97, StdDev = 60.426 us
+Min = 200.955 us, Q1 = 257.791 us, Median = 280.547 us, Q3 = 347.046 us, Max = 438.721 us
+IQR = 89.255 us, LowerFence = 123.907 us, UpperFence = 480.929 us
+ConfidenceInterval = [282.171 us; 323.827 us] (CI 99.9%), Margin = 20.828 us (6.87% of Mean)
+Skewness = 0.66, Kurtosis = 2.36, MValue = 2.61
+
+// **************************
+// Benchmark: CountBenchmarks.List: DefaultJob [N=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.List(N: 1000)" --job "Default" --benchmarkId 7 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 724225.00 ns, 724.2250 us/op
+WorkloadJitting  1: 1 op, 9919334.00 ns, 9.9193 ms/op
+
+OverheadJitting  2: 16 op, 2242784.00 ns, 140.1740 us/op
+WorkloadJitting  2: 16 op, 46262176.00 ns, 2.8914 ms/op
+
+WorkloadPilot    1: 16 op, 28337951.00 ns, 1.7711 ms/op
+WorkloadPilot    2: 32 op, 64191780.00 ns, 2.0060 ms/op
+WorkloadPilot    3: 64 op, 145823011.00 ns, 2.2785 ms/op
+WorkloadPilot    4: 128 op, 277787517.00 ns, 2.1702 ms/op
+WorkloadPilot    5: 256 op, 640731990.00 ns, 2.5029 ms/op
+
+OverheadWarmup   1: 256 op, 23190.00 ns, 90.5859 ns/op
+OverheadWarmup   2: 256 op, 13480.00 ns, 52.6562 ns/op
+OverheadWarmup   3: 256 op, 16587.00 ns, 64.7930 ns/op
+OverheadWarmup   4: 256 op, 15837.00 ns, 61.8633 ns/op
+OverheadWarmup   5: 256 op, 21154.00 ns, 82.6328 ns/op
+OverheadWarmup   6: 256 op, 21511.00 ns, 84.0273 ns/op
+OverheadWarmup   7: 256 op, 19077.00 ns, 74.5195 ns/op
+
+OverheadActual   1: 256 op, 21570.00 ns, 84.2578 ns/op
+OverheadActual   2: 256 op, 14730.00 ns, 57.5391 ns/op
+OverheadActual   3: 256 op, 14950.00 ns, 58.3984 ns/op
+OverheadActual   4: 256 op, 14004.00 ns, 54.7031 ns/op
+OverheadActual   5: 256 op, 17708.00 ns, 69.1719 ns/op
+OverheadActual   6: 256 op, 19364.00 ns, 75.6406 ns/op
+OverheadActual   7: 256 op, 19182.00 ns, 74.9297 ns/op
+OverheadActual   8: 256 op, 19672.00 ns, 76.8438 ns/op
+OverheadActual   9: 256 op, 19645.00 ns, 76.7383 ns/op
+OverheadActual  10: 256 op, 21514.00 ns, 84.0391 ns/op
+OverheadActual  11: 256 op, 20790.00 ns, 81.2109 ns/op
+OverheadActual  12: 256 op, 19502.00 ns, 76.1797 ns/op
+OverheadActual  13: 256 op, 20848.00 ns, 81.4375 ns/op
+OverheadActual  14: 256 op, 20424.00 ns, 79.7812 ns/op
+OverheadActual  15: 256 op, 23192.00 ns, 90.5938 ns/op
+OverheadActual  16: 256 op, 20275.00 ns, 79.1992 ns/op
+OverheadActual  17: 256 op, 21616.00 ns, 84.4375 ns/op
+OverheadActual  18: 256 op, 14381.00 ns, 56.1758 ns/op
+OverheadActual  19: 256 op, 20741.00 ns, 81.0195 ns/op
+OverheadActual  20: 256 op, 41440.00 ns, 161.8750 ns/op
+
+WorkloadWarmup   1: 256 op, 550803345.00 ns, 2.1516 ms/op
+WorkloadWarmup   2: 256 op, 562917314.00 ns, 2.1989 ms/op
+WorkloadWarmup   3: 256 op, 415877131.00 ns, 1.6245 ms/op
+WorkloadWarmup   4: 256 op, 132205444.00 ns, 516.4275 us/op
+WorkloadWarmup   5: 256 op, 95458064.00 ns, 372.8831 us/op
+WorkloadWarmup   6: 256 op, 105003671.00 ns, 410.1706 us/op
+WorkloadWarmup   7: 256 op, 93608132.00 ns, 365.6568 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 256 op, 92795279.00 ns, 362.4816 us/op
+WorkloadActual   2: 256 op, 82780541.00 ns, 323.3615 us/op
+WorkloadActual   3: 256 op, 93394200.00 ns, 364.8211 us/op
+WorkloadActual   4: 256 op, 99857324.00 ns, 390.0677 us/op
+WorkloadActual   5: 256 op, 89470646.00 ns, 349.4947 us/op
+WorkloadActual   6: 256 op, 91246913.00 ns, 356.4333 us/op
+WorkloadActual   7: 256 op, 87366609.00 ns, 341.2758 us/op
+WorkloadActual   8: 256 op, 84176047.00 ns, 328.8127 us/op
+WorkloadActual   9: 256 op, 90079304.00 ns, 351.8723 us/op
+WorkloadActual  10: 256 op, 86878546.00 ns, 339.3693 us/op
+WorkloadActual  11: 256 op, 111691314.00 ns, 436.2942 us/op
+WorkloadActual  12: 256 op, 80864620.00 ns, 315.8774 us/op
+WorkloadActual  13: 256 op, 87334836.00 ns, 341.1517 us/op
+WorkloadActual  14: 256 op, 97594372.00 ns, 381.2280 us/op
+WorkloadActual  15: 256 op, 84266666.00 ns, 329.1667 us/op
+WorkloadActual  16: 256 op, 87032973.00 ns, 339.9726 us/op
+WorkloadActual  17: 256 op, 86490787.00 ns, 337.8546 us/op
+WorkloadActual  18: 256 op, 84203039.00 ns, 328.9181 us/op
+WorkloadActual  19: 256 op, 88913657.00 ns, 347.3190 us/op
+WorkloadActual  20: 256 op, 97801632.00 ns, 382.0376 us/op
+WorkloadActual  21: 256 op, 121161369.00 ns, 473.2866 us/op
+WorkloadActual  22: 256 op, 105671260.00 ns, 412.7784 us/op
+WorkloadActual  23: 256 op, 89098071.00 ns, 348.0393 us/op
+WorkloadActual  24: 256 op, 101745256.00 ns, 397.4424 us/op
+WorkloadActual  25: 256 op, 97804261.00 ns, 382.0479 us/op
+WorkloadActual  26: 256 op, 97807465.00 ns, 382.0604 us/op
+WorkloadActual  27: 256 op, 92363567.00 ns, 360.7952 us/op
+WorkloadActual  28: 256 op, 84568608.00 ns, 330.3461 us/op
+WorkloadActual  29: 256 op, 107247997.00 ns, 418.9375 us/op
+WorkloadActual  30: 256 op, 88774614.00 ns, 346.7758 us/op
+WorkloadActual  31: 256 op, 88441556.00 ns, 345.4748 us/op
+WorkloadActual  32: 256 op, 138220238.00 ns, 539.9228 us/op
+WorkloadActual  33: 256 op, 89160817.00 ns, 348.2844 us/op
+WorkloadActual  34: 256 op, 95538358.00 ns, 373.1967 us/op
+WorkloadActual  35: 256 op, 123449719.00 ns, 482.2255 us/op
+WorkloadActual  36: 256 op, 148881684.00 ns, 581.5691 us/op
+WorkloadActual  37: 256 op, 96359400.00 ns, 376.4039 us/op
+WorkloadActual  38: 256 op, 104765000.00 ns, 409.2383 us/op
+WorkloadActual  39: 256 op, 90093373.00 ns, 351.9272 us/op
+WorkloadActual  40: 256 op, 79525878.00 ns, 310.6480 us/op
+WorkloadActual  41: 256 op, 82205415.00 ns, 321.1149 us/op
+WorkloadActual  42: 256 op, 83112768.00 ns, 324.6592 us/op
+WorkloadActual  43: 256 op, 91487690.00 ns, 357.3738 us/op
+WorkloadActual  44: 256 op, 92719660.00 ns, 362.1862 us/op
+WorkloadActual  45: 256 op, 82607572.00 ns, 322.6858 us/op
+WorkloadActual  46: 256 op, 83520782.00 ns, 326.2531 us/op
+WorkloadActual  47: 256 op, 84025475.00 ns, 328.2245 us/op
+WorkloadActual  48: 256 op, 84968988.00 ns, 331.9101 us/op
+WorkloadActual  49: 256 op, 91457995.00 ns, 357.2578 us/op
+WorkloadActual  50: 256 op, 76664715.00 ns, 299.4715 us/op
+WorkloadActual  51: 256 op, 78217841.00 ns, 305.5384 us/op
+WorkloadActual  52: 256 op, 83896676.00 ns, 327.7214 us/op
+WorkloadActual  53: 256 op, 113093765.00 ns, 441.7725 us/op
+WorkloadActual  54: 256 op, 112248524.00 ns, 438.4708 us/op
+WorkloadActual  55: 256 op, 115985850.00 ns, 453.0697 us/op
+WorkloadActual  56: 256 op, 117037953.00 ns, 457.1795 us/op
+WorkloadActual  57: 256 op, 107286065.00 ns, 419.0862 us/op
+WorkloadActual  58: 256 op, 96546469.00 ns, 377.1346 us/op
+WorkloadActual  59: 256 op, 79829680.00 ns, 311.8347 us/op
+WorkloadActual  60: 256 op, 89818394.00 ns, 350.8531 us/op
+WorkloadActual  61: 256 op, 97018838.00 ns, 378.9798 us/op
+WorkloadActual  62: 256 op, 87688157.00 ns, 342.5319 us/op
+WorkloadActual  63: 256 op, 82490756.00 ns, 322.2295 us/op
+WorkloadActual  64: 256 op, 80839321.00 ns, 315.7786 us/op
+WorkloadActual  65: 256 op, 79008677.00 ns, 308.6276 us/op
+WorkloadActual  66: 256 op, 76965989.00 ns, 300.6484 us/op
+WorkloadActual  67: 256 op, 84725198.00 ns, 330.9578 us/op
+WorkloadActual  68: 256 op, 94795062.00 ns, 370.2932 us/op
+WorkloadActual  69: 256 op, 94375898.00 ns, 368.6559 us/op
+WorkloadActual  70: 256 op, 92300502.00 ns, 360.5488 us/op
+WorkloadActual  71: 256 op, 94333748.00 ns, 368.4912 us/op
+WorkloadActual  72: 256 op, 92993518.00 ns, 363.2559 us/op
+WorkloadActual  73: 256 op, 99909228.00 ns, 390.2704 us/op
+WorkloadActual  74: 256 op, 126278347.00 ns, 493.2748 us/op
+WorkloadActual  75: 256 op, 84377191.00 ns, 329.5984 us/op
+WorkloadActual  76: 256 op, 84733401.00 ns, 330.9898 us/op
+WorkloadActual  77: 256 op, 69837409.00 ns, 272.8024 us/op
+WorkloadActual  78: 256 op, 73401447.00 ns, 286.7244 us/op
+WorkloadActual  79: 256 op, 79437312.00 ns, 310.3020 us/op
+WorkloadActual  80: 256 op, 73674079.00 ns, 287.7894 us/op
+WorkloadActual  81: 256 op, 84644984.00 ns, 330.6445 us/op
+WorkloadActual  82: 256 op, 89004906.00 ns, 347.6754 us/op
+WorkloadActual  83: 256 op, 116631910.00 ns, 455.5934 us/op
+WorkloadActual  84: 256 op, 111419785.00 ns, 435.2335 us/op
+WorkloadActual  85: 256 op, 115881626.00 ns, 452.6626 us/op
+WorkloadActual  86: 256 op, 122586830.00 ns, 478.8548 us/op
+WorkloadActual  87: 256 op, 70301741.00 ns, 274.6162 us/op
+WorkloadActual  88: 256 op, 67776575.00 ns, 264.7522 us/op
+WorkloadActual  89: 256 op, 97024488.00 ns, 379.0019 us/op
+WorkloadActual  90: 256 op, 74245672.00 ns, 290.0222 us/op
+WorkloadActual  91: 256 op, 76831918.00 ns, 300.1247 us/op
+WorkloadActual  92: 256 op, 92293596.00 ns, 360.5219 us/op
+WorkloadActual  93: 256 op, 79471198.00 ns, 310.4344 us/op
+WorkloadActual  94: 256 op, 68203266.00 ns, 266.4190 us/op
+WorkloadActual  95: 256 op, 74046762.00 ns, 289.2452 us/op
+WorkloadActual  96: 256 op, 82318037.00 ns, 321.5548 us/op
+WorkloadActual  97: 256 op, 68866744.00 ns, 269.0107 us/op
+WorkloadActual  98: 256 op, 76039181.00 ns, 297.0281 us/op
+WorkloadActual  99: 256 op, 71437029.00 ns, 279.0509 us/op
+WorkloadActual  100: 256 op, 61419977.00 ns, 239.9218 us/op
+
+// AfterActualRun
+WorkloadResult   1: 256 op, 92775305.50 ns, 362.4035 us/op
+WorkloadResult   2: 256 op, 82760567.50 ns, 323.2835 us/op
+WorkloadResult   3: 256 op, 93374226.50 ns, 364.7431 us/op
+WorkloadResult   4: 256 op, 99837350.50 ns, 389.9897 us/op
+WorkloadResult   5: 256 op, 89450672.50 ns, 349.4167 us/op
+WorkloadResult   6: 256 op, 91226939.50 ns, 356.3552 us/op
+WorkloadResult   7: 256 op, 87346635.50 ns, 341.1978 us/op
+WorkloadResult   8: 256 op, 84156073.50 ns, 328.7347 us/op
+WorkloadResult   9: 256 op, 90059330.50 ns, 351.7943 us/op
+WorkloadResult  10: 256 op, 86858572.50 ns, 339.2913 us/op
+WorkloadResult  11: 256 op, 111671340.50 ns, 436.2162 us/op
+WorkloadResult  12: 256 op, 80844646.50 ns, 315.7994 us/op
+WorkloadResult  13: 256 op, 87314862.50 ns, 341.0737 us/op
+WorkloadResult  14: 256 op, 97574398.50 ns, 381.1500 us/op
+WorkloadResult  15: 256 op, 84246692.50 ns, 329.0886 us/op
+WorkloadResult  16: 256 op, 87012999.50 ns, 339.8945 us/op
+WorkloadResult  17: 256 op, 86470813.50 ns, 337.7766 us/op
+WorkloadResult  18: 256 op, 84183065.50 ns, 328.8401 us/op
+WorkloadResult  19: 256 op, 88893683.50 ns, 347.2410 us/op
+WorkloadResult  20: 256 op, 97781658.50 ns, 381.9596 us/op
+WorkloadResult  21: 256 op, 105651286.50 ns, 412.7003 us/op
+WorkloadResult  22: 256 op, 89078097.50 ns, 347.9613 us/op
+WorkloadResult  23: 256 op, 101725282.50 ns, 397.3644 us/op
+WorkloadResult  24: 256 op, 97784287.50 ns, 381.9699 us/op
+WorkloadResult  25: 256 op, 97787491.50 ns, 381.9824 us/op
+WorkloadResult  26: 256 op, 92343593.50 ns, 360.7172 us/op
+WorkloadResult  27: 256 op, 84548634.50 ns, 330.2681 us/op
+WorkloadResult  28: 256 op, 107228023.50 ns, 418.8595 us/op
+WorkloadResult  29: 256 op, 88754640.50 ns, 346.6978 us/op
+WorkloadResult  30: 256 op, 88421582.50 ns, 345.3968 us/op
+WorkloadResult  31: 256 op, 89140843.50 ns, 348.2064 us/op
+WorkloadResult  32: 256 op, 95518384.50 ns, 373.1187 us/op
+WorkloadResult  33: 256 op, 96339426.50 ns, 376.3259 us/op
+WorkloadResult  34: 256 op, 104745026.50 ns, 409.1603 us/op
+WorkloadResult  35: 256 op, 90073399.50 ns, 351.8492 us/op
+WorkloadResult  36: 256 op, 79505904.50 ns, 310.5699 us/op
+WorkloadResult  37: 256 op, 82185441.50 ns, 321.0369 us/op
+WorkloadResult  38: 256 op, 83092794.50 ns, 324.5812 us/op
+WorkloadResult  39: 256 op, 91467716.50 ns, 357.2958 us/op
+WorkloadResult  40: 256 op, 92699686.50 ns, 362.1082 us/op
+WorkloadResult  41: 256 op, 82587598.50 ns, 322.6078 us/op
+WorkloadResult  42: 256 op, 83500808.50 ns, 326.1750 us/op
+WorkloadResult  43: 256 op, 84005501.50 ns, 328.1465 us/op
+WorkloadResult  44: 256 op, 84949014.50 ns, 331.8321 us/op
+WorkloadResult  45: 256 op, 91438021.50 ns, 357.1798 us/op
+WorkloadResult  46: 256 op, 76644741.50 ns, 299.3935 us/op
+WorkloadResult  47: 256 op, 78197867.50 ns, 305.4604 us/op
+WorkloadResult  48: 256 op, 83876702.50 ns, 327.6434 us/op
+WorkloadResult  49: 256 op, 113073791.50 ns, 441.6945 us/op
+WorkloadResult  50: 256 op, 112228550.50 ns, 438.3928 us/op
+WorkloadResult  51: 256 op, 115965876.50 ns, 452.9917 us/op
+WorkloadResult  52: 256 op, 117017979.50 ns, 457.1015 us/op
+WorkloadResult  53: 256 op, 107266091.50 ns, 419.0082 us/op
+WorkloadResult  54: 256 op, 96526495.50 ns, 377.0566 us/op
+WorkloadResult  55: 256 op, 79809706.50 ns, 311.7567 us/op
+WorkloadResult  56: 256 op, 89798420.50 ns, 350.7751 us/op
+WorkloadResult  57: 256 op, 96998864.50 ns, 378.9018 us/op
+WorkloadResult  58: 256 op, 87668183.50 ns, 342.4538 us/op
+WorkloadResult  59: 256 op, 82470782.50 ns, 322.1515 us/op
+WorkloadResult  60: 256 op, 80819347.50 ns, 315.7006 us/op
+WorkloadResult  61: 256 op, 78988703.50 ns, 308.5496 us/op
+WorkloadResult  62: 256 op, 76946015.50 ns, 300.5704 us/op
+WorkloadResult  63: 256 op, 84705224.50 ns, 330.8798 us/op
+WorkloadResult  64: 256 op, 94775088.50 ns, 370.2152 us/op
+WorkloadResult  65: 256 op, 94355924.50 ns, 368.5778 us/op
+WorkloadResult  66: 256 op, 92280528.50 ns, 360.4708 us/op
+WorkloadResult  67: 256 op, 94313774.50 ns, 368.4132 us/op
+WorkloadResult  68: 256 op, 92973544.50 ns, 363.1779 us/op
+WorkloadResult  69: 256 op, 99889254.50 ns, 390.1924 us/op
+WorkloadResult  70: 256 op, 84357217.50 ns, 329.5204 us/op
+WorkloadResult  71: 256 op, 84713427.50 ns, 330.9118 us/op
+WorkloadResult  72: 256 op, 69817435.50 ns, 272.7244 us/op
+WorkloadResult  73: 256 op, 73381473.50 ns, 286.6464 us/op
+WorkloadResult  74: 256 op, 79417338.50 ns, 310.2240 us/op
+WorkloadResult  75: 256 op, 73654105.50 ns, 287.7113 us/op
+WorkloadResult  76: 256 op, 84625010.50 ns, 330.5664 us/op
+WorkloadResult  77: 256 op, 88984932.50 ns, 347.5974 us/op
+WorkloadResult  78: 256 op, 116611936.50 ns, 455.5154 us/op
+WorkloadResult  79: 256 op, 111399811.50 ns, 435.1555 us/op
+WorkloadResult  80: 256 op, 115861652.50 ns, 452.5846 us/op
+WorkloadResult  81: 256 op, 70281767.50 ns, 274.5382 us/op
+WorkloadResult  82: 256 op, 67756601.50 ns, 264.6742 us/op
+WorkloadResult  83: 256 op, 97004514.50 ns, 378.9239 us/op
+WorkloadResult  84: 256 op, 74225698.50 ns, 289.9441 us/op
+WorkloadResult  85: 256 op, 76811944.50 ns, 300.0467 us/op
+WorkloadResult  86: 256 op, 92273622.50 ns, 360.4438 us/op
+WorkloadResult  87: 256 op, 79451224.50 ns, 310.3563 us/op
+WorkloadResult  88: 256 op, 68183292.50 ns, 266.3410 us/op
+WorkloadResult  89: 256 op, 74026788.50 ns, 289.1671 us/op
+WorkloadResult  90: 256 op, 82298063.50 ns, 321.4768 us/op
+WorkloadResult  91: 256 op, 68846770.50 ns, 268.9327 us/op
+WorkloadResult  92: 256 op, 76019207.50 ns, 296.9500 us/op
+WorkloadResult  93: 256 op, 71417055.50 ns, 278.9729 us/op
+WorkloadResult  94: 256 op, 61400003.50 ns, 239.8438 us/op
+GC:  3 1 0 29037216 256
+Threading:  0 0 256
+
+// AfterAll
+// Benchmark Process 1257210 has exited with code 0.
+
+Mean = 347.358 us, StdErr = 4.831 us (1.39%), N = 94, StdDev = 46.841 us
+Min = 239.844 us, Q1 = 321.147 us, Median = 343.925 us, Q3 = 372.393 us, Max = 457.101 us
+IQR = 51.246 us, LowerFence = 244.278 us, UpperFence = 449.262 us
+ConfidenceInterval = [330.940 us; 363.776 us] (CI 99.9%), Margin = 16.418 us (4.73% of Mean)
+Skewness = 0.42, Kurtosis = 2.96, MValue = 2.08
+
+// **************************
+// Benchmark: CountBenchmarks.ListWithCapacity: DefaultJob [N=1000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.ListWithCapacity(N: 1000)" --job "Default" --benchmarkId 8 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 806480.00 ns, 806.4800 us/op
+WorkloadJitting  1: 1 op, 29577964.00 ns, 29.5780 ms/op
+
+OverheadJitting  2: 16 op, 2431640.00 ns, 151.9775 us/op
+WorkloadJitting  2: 16 op, 51686088.00 ns, 3.2304 ms/op
+
+WorkloadPilot    1: 16 op, 49275801.00 ns, 3.0797 ms/op
+WorkloadPilot    2: 32 op, 82582354.00 ns, 2.5807 ms/op
+WorkloadPilot    3: 64 op, 162326854.00 ns, 2.5364 ms/op
+WorkloadPilot    4: 128 op, 310694149.00 ns, 2.4273 ms/op
+WorkloadPilot    5: 256 op, 558768865.00 ns, 2.1827 ms/op
+
+OverheadWarmup   1: 256 op, 15110.00 ns, 59.0234 ns/op
+OverheadWarmup   2: 256 op, 20478.00 ns, 79.9922 ns/op
+OverheadWarmup   3: 256 op, 20564.00 ns, 80.3281 ns/op
+OverheadWarmup   4: 256 op, 14088.00 ns, 55.0312 ns/op
+OverheadWarmup   5: 256 op, 22681.00 ns, 88.5977 ns/op
+OverheadWarmup   6: 256 op, 15287.00 ns, 59.7148 ns/op
+
+OverheadActual   1: 256 op, 14569.00 ns, 56.9102 ns/op
+OverheadActual   2: 256 op, 14923.00 ns, 58.2930 ns/op
+OverheadActual   3: 256 op, 22874.00 ns, 89.3516 ns/op
+OverheadActual   4: 256 op, 16017.00 ns, 62.5664 ns/op
+OverheadActual   5: 256 op, 17220.00 ns, 67.2656 ns/op
+OverheadActual   6: 256 op, 13788.00 ns, 53.8594 ns/op
+OverheadActual   7: 256 op, 13440.00 ns, 52.5000 ns/op
+OverheadActual   8: 256 op, 12545.00 ns, 49.0039 ns/op
+OverheadActual   9: 256 op, 11777.00 ns, 46.0039 ns/op
+OverheadActual  10: 256 op, 20059.00 ns, 78.3555 ns/op
+OverheadActual  11: 256 op, 18135.00 ns, 70.8398 ns/op
+OverheadActual  12: 256 op, 12554.00 ns, 49.0391 ns/op
+OverheadActual  13: 256 op, 12659.00 ns, 49.4492 ns/op
+OverheadActual  14: 256 op, 12206.00 ns, 47.6797 ns/op
+OverheadActual  15: 256 op, 12126.00 ns, 47.3672 ns/op
+OverheadActual  16: 256 op, 19315.00 ns, 75.4492 ns/op
+OverheadActual  17: 256 op, 12966.00 ns, 50.6484 ns/op
+OverheadActual  18: 256 op, 13329.00 ns, 52.0664 ns/op
+OverheadActual  19: 256 op, 19332.00 ns, 75.5156 ns/op
+OverheadActual  20: 256 op, 12560.00 ns, 49.0625 ns/op
+
+WorkloadWarmup   1: 256 op, 426825099.00 ns, 1.6673 ms/op
+WorkloadWarmup   2: 256 op, 429827245.00 ns, 1.6790 ms/op
+WorkloadWarmup   3: 256 op, 497363576.00 ns, 1.9428 ms/op
+WorkloadWarmup   4: 256 op, 127760427.00 ns, 499.0642 us/op
+WorkloadWarmup   5: 256 op, 98464738.00 ns, 384.6279 us/op
+WorkloadWarmup   6: 256 op, 96485740.00 ns, 376.8974 us/op
+WorkloadWarmup   7: 256 op, 81344370.00 ns, 317.7514 us/op
+WorkloadWarmup   8: 256 op, 68305322.00 ns, 266.8177 us/op
+WorkloadWarmup   9: 256 op, 70538080.00 ns, 275.5394 us/op
+WorkloadWarmup  10: 256 op, 64279324.00 ns, 251.0911 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 256 op, 97260292.00 ns, 379.9230 us/op
+WorkloadActual   2: 256 op, 82124905.00 ns, 320.8004 us/op
+WorkloadActual   3: 256 op, 75131326.00 ns, 293.4817 us/op
+WorkloadActual   4: 256 op, 78202107.00 ns, 305.4770 us/op
+WorkloadActual   5: 256 op, 83857977.00 ns, 327.5702 us/op
+WorkloadActual   6: 256 op, 89757973.00 ns, 350.6171 us/op
+WorkloadActual   7: 256 op, 84217167.00 ns, 328.9733 us/op
+WorkloadActual   8: 256 op, 82619527.00 ns, 322.7325 us/op
+WorkloadActual   9: 256 op, 66298963.00 ns, 258.9803 us/op
+WorkloadActual  10: 256 op, 79313222.00 ns, 309.8173 us/op
+WorkloadActual  11: 256 op, 78171357.00 ns, 305.3569 us/op
+WorkloadActual  12: 256 op, 61798537.00 ns, 241.4005 us/op
+WorkloadActual  13: 256 op, 70325867.00 ns, 274.7104 us/op
+WorkloadActual  14: 256 op, 74252513.00 ns, 290.0489 us/op
+WorkloadActual  15: 256 op, 69085480.00 ns, 269.8652 us/op
+WorkloadActual  16: 256 op, 72723167.00 ns, 284.0749 us/op
+WorkloadActual  17: 256 op, 72597797.00 ns, 283.5851 us/op
+WorkloadActual  18: 256 op, 65550897.00 ns, 256.0582 us/op
+WorkloadActual  19: 256 op, 78718104.00 ns, 307.4926 us/op
+WorkloadActual  20: 256 op, 117522002.00 ns, 459.0703 us/op
+WorkloadActual  21: 256 op, 166649422.00 ns, 650.9743 us/op
+WorkloadActual  22: 256 op, 90901772.00 ns, 355.0850 us/op
+WorkloadActual  23: 256 op, 87395901.00 ns, 341.3902 us/op
+WorkloadActual  24: 256 op, 81933215.00 ns, 320.0516 us/op
+WorkloadActual  25: 256 op, 70643447.00 ns, 275.9510 us/op
+WorkloadActual  26: 256 op, 66648690.00 ns, 260.3464 us/op
+WorkloadActual  27: 256 op, 66333351.00 ns, 259.1147 us/op
+WorkloadActual  28: 256 op, 68513808.00 ns, 267.6321 us/op
+WorkloadActual  29: 256 op, 64297389.00 ns, 251.1617 us/op
+WorkloadActual  30: 256 op, 58293253.00 ns, 227.7080 us/op
+WorkloadActual  31: 256 op, 71607080.00 ns, 279.7152 us/op
+WorkloadActual  32: 256 op, 78391711.00 ns, 306.2176 us/op
+WorkloadActual  33: 256 op, 79344211.00 ns, 309.9383 us/op
+WorkloadActual  34: 256 op, 104173865.00 ns, 406.9292 us/op
+WorkloadActual  35: 256 op, 98521868.00 ns, 384.8510 us/op
+WorkloadActual  36: 256 op, 78085972.00 ns, 305.0233 us/op
+WorkloadActual  37: 256 op, 79798871.00 ns, 311.7143 us/op
+WorkloadActual  38: 256 op, 90046812.00 ns, 351.7454 us/op
+WorkloadActual  39: 256 op, 88054110.00 ns, 343.9614 us/op
+WorkloadActual  40: 256 op, 91710374.00 ns, 358.2436 us/op
+WorkloadActual  41: 256 op, 93940418.00 ns, 366.9548 us/op
+WorkloadActual  42: 256 op, 90376088.00 ns, 353.0316 us/op
+WorkloadActual  43: 256 op, 110644050.00 ns, 432.2033 us/op
+WorkloadActual  44: 256 op, 89473129.00 ns, 349.5044 us/op
+WorkloadActual  45: 256 op, 128656436.00 ns, 502.5642 us/op
+WorkloadActual  46: 256 op, 112711263.00 ns, 440.2784 us/op
+WorkloadActual  47: 256 op, 107478187.00 ns, 419.8367 us/op
+WorkloadActual  48: 256 op, 106021680.00 ns, 414.1472 us/op
+WorkloadActual  49: 256 op, 96966233.00 ns, 378.7743 us/op
+WorkloadActual  50: 256 op, 75793733.00 ns, 296.0693 us/op
+WorkloadActual  51: 256 op, 90850877.00 ns, 354.8862 us/op
+WorkloadActual  52: 256 op, 97787885.00 ns, 381.9839 us/op
+WorkloadActual  53: 256 op, 87091640.00 ns, 340.2017 us/op
+WorkloadActual  54: 256 op, 86246890.00 ns, 336.9019 us/op
+WorkloadActual  55: 256 op, 71097069.00 ns, 277.7229 us/op
+WorkloadActual  56: 256 op, 68519244.00 ns, 267.6533 us/op
+WorkloadActual  57: 256 op, 79894427.00 ns, 312.0876 us/op
+WorkloadActual  58: 256 op, 98480345.00 ns, 384.6888 us/op
+WorkloadActual  59: 256 op, 91000680.00 ns, 355.4714 us/op
+WorkloadActual  60: 256 op, 88456474.00 ns, 345.5331 us/op
+WorkloadActual  61: 256 op, 70778918.00 ns, 276.4801 us/op
+WorkloadActual  62: 256 op, 75253737.00 ns, 293.9599 us/op
+WorkloadActual  63: 256 op, 77515053.00 ns, 302.7932 us/op
+WorkloadActual  64: 256 op, 98895266.00 ns, 386.3096 us/op
+WorkloadActual  65: 256 op, 88400011.00 ns, 345.3125 us/op
+WorkloadActual  66: 256 op, 97041858.00 ns, 379.0698 us/op
+WorkloadActual  67: 256 op, 106037317.00 ns, 414.2083 us/op
+WorkloadActual  68: 256 op, 103933604.00 ns, 405.9906 us/op
+WorkloadActual  69: 256 op, 101285288.00 ns, 395.6457 us/op
+WorkloadActual  70: 256 op, 92196362.00 ns, 360.1420 us/op
+WorkloadActual  71: 256 op, 80694343.00 ns, 315.2123 us/op
+WorkloadActual  72: 256 op, 87017239.00 ns, 339.9111 us/op
+WorkloadActual  73: 256 op, 104092627.00 ns, 406.6118 us/op
+WorkloadActual  74: 256 op, 90109714.00 ns, 351.9911 us/op
+WorkloadActual  75: 256 op, 97959040.00 ns, 382.6525 us/op
+WorkloadActual  76: 256 op, 107587002.00 ns, 420.2617 us/op
+WorkloadActual  77: 256 op, 90487728.00 ns, 353.4677 us/op
+WorkloadActual  78: 256 op, 73763840.00 ns, 288.1400 us/op
+WorkloadActual  79: 256 op, 71290300.00 ns, 278.4777 us/op
+WorkloadActual  80: 256 op, 63962976.00 ns, 249.8554 us/op
+WorkloadActual  81: 256 op, 54514812.00 ns, 212.9485 us/op
+WorkloadActual  82: 256 op, 71837841.00 ns, 280.6166 us/op
+WorkloadActual  83: 256 op, 74457035.00 ns, 290.8478 us/op
+WorkloadActual  84: 256 op, 59754317.00 ns, 233.4153 us/op
+WorkloadActual  85: 256 op, 76116247.00 ns, 297.3291 us/op
+WorkloadActual  86: 256 op, 66565288.00 ns, 260.0207 us/op
+WorkloadActual  87: 256 op, 76783062.00 ns, 299.9338 us/op
+WorkloadActual  88: 256 op, 74480536.00 ns, 290.9396 us/op
+WorkloadActual  89: 256 op, 91143553.00 ns, 356.0295 us/op
+WorkloadActual  90: 256 op, 88256321.00 ns, 344.7513 us/op
+WorkloadActual  91: 256 op, 78320696.00 ns, 305.9402 us/op
+WorkloadActual  92: 256 op, 72346494.00 ns, 282.6035 us/op
+WorkloadActual  93: 256 op, 58329377.00 ns, 227.8491 us/op
+WorkloadActual  94: 256 op, 84840678.00 ns, 331.4089 us/op
+WorkloadActual  95: 256 op, 77727460.00 ns, 303.6229 us/op
+WorkloadActual  96: 256 op, 63490859.00 ns, 248.0112 us/op
+WorkloadActual  97: 256 op, 59909129.00 ns, 234.0200 us/op
+WorkloadActual  98: 256 op, 99939042.00 ns, 390.3869 us/op
+WorkloadActual  99: 256 op, 91063577.00 ns, 355.7171 us/op
+WorkloadActual  100: 256 op, 72282613.00 ns, 282.3540 us/op
+
+// AfterActualRun
+WorkloadResult   1: 256 op, 97246678.00 ns, 379.8698 us/op
+WorkloadResult   2: 256 op, 82111291.00 ns, 320.7472 us/op
+WorkloadResult   3: 256 op, 75117712.00 ns, 293.4286 us/op
+WorkloadResult   4: 256 op, 78188493.00 ns, 305.4238 us/op
+WorkloadResult   5: 256 op, 83844363.00 ns, 327.5170 us/op
+WorkloadResult   6: 256 op, 89744359.00 ns, 350.5639 us/op
+WorkloadResult   7: 256 op, 84203553.00 ns, 328.9201 us/op
+WorkloadResult   8: 256 op, 82605913.00 ns, 322.6793 us/op
+WorkloadResult   9: 256 op, 66285349.00 ns, 258.9271 us/op
+WorkloadResult  10: 256 op, 79299608.00 ns, 309.7641 us/op
+WorkloadResult  11: 256 op, 78157743.00 ns, 305.3037 us/op
+WorkloadResult  12: 256 op, 61784923.00 ns, 241.3474 us/op
+WorkloadResult  13: 256 op, 70312253.00 ns, 274.6572 us/op
+WorkloadResult  14: 256 op, 74238899.00 ns, 289.9957 us/op
+WorkloadResult  15: 256 op, 69071866.00 ns, 269.8120 us/op
+WorkloadResult  16: 256 op, 72709553.00 ns, 284.0217 us/op
+WorkloadResult  17: 256 op, 72584183.00 ns, 283.5320 us/op
+WorkloadResult  18: 256 op, 65537283.00 ns, 256.0050 us/op
+WorkloadResult  19: 256 op, 78704490.00 ns, 307.4394 us/op
+WorkloadResult  20: 256 op, 117508388.00 ns, 459.0171 us/op
+WorkloadResult  21: 256 op, 90888158.00 ns, 355.0319 us/op
+WorkloadResult  22: 256 op, 87382287.00 ns, 341.3371 us/op
+WorkloadResult  23: 256 op, 81919601.00 ns, 319.9984 us/op
+WorkloadResult  24: 256 op, 70629833.00 ns, 275.8978 us/op
+WorkloadResult  25: 256 op, 66635076.00 ns, 260.2933 us/op
+WorkloadResult  26: 256 op, 66319737.00 ns, 259.0615 us/op
+WorkloadResult  27: 256 op, 68500194.00 ns, 267.5789 us/op
+WorkloadResult  28: 256 op, 64283775.00 ns, 251.1085 us/op
+WorkloadResult  29: 256 op, 58279639.00 ns, 227.6548 us/op
+WorkloadResult  30: 256 op, 71593466.00 ns, 279.6620 us/op
+WorkloadResult  31: 256 op, 78378097.00 ns, 306.1644 us/op
+WorkloadResult  32: 256 op, 79330597.00 ns, 309.8851 us/op
+WorkloadResult  33: 256 op, 104160251.00 ns, 406.8760 us/op
+WorkloadResult  34: 256 op, 98508254.00 ns, 384.7979 us/op
+WorkloadResult  35: 256 op, 78072358.00 ns, 304.9701 us/op
+WorkloadResult  36: 256 op, 79785257.00 ns, 311.6612 us/op
+WorkloadResult  37: 256 op, 90033198.00 ns, 351.6922 us/op
+WorkloadResult  38: 256 op, 88040496.00 ns, 343.9082 us/op
+WorkloadResult  39: 256 op, 91696760.00 ns, 358.1905 us/op
+WorkloadResult  40: 256 op, 93926804.00 ns, 366.9016 us/op
+WorkloadResult  41: 256 op, 90362474.00 ns, 352.9784 us/op
+WorkloadResult  42: 256 op, 110630436.00 ns, 432.1501 us/op
+WorkloadResult  43: 256 op, 89459515.00 ns, 349.4512 us/op
+WorkloadResult  44: 256 op, 112697649.00 ns, 440.2252 us/op
+WorkloadResult  45: 256 op, 107464573.00 ns, 419.7835 us/op
+WorkloadResult  46: 256 op, 106008066.00 ns, 414.0940 us/op
+WorkloadResult  47: 256 op, 96952619.00 ns, 378.7212 us/op
+WorkloadResult  48: 256 op, 75780119.00 ns, 296.0161 us/op
+WorkloadResult  49: 256 op, 90837263.00 ns, 354.8331 us/op
+WorkloadResult  50: 256 op, 97774271.00 ns, 381.9307 us/op
+WorkloadResult  51: 256 op, 87078026.00 ns, 340.1485 us/op
+WorkloadResult  52: 256 op, 86233276.00 ns, 336.8487 us/op
+WorkloadResult  53: 256 op, 71083455.00 ns, 277.6697 us/op
+WorkloadResult  54: 256 op, 68505630.00 ns, 267.6001 us/op
+WorkloadResult  55: 256 op, 79880813.00 ns, 312.0344 us/op
+WorkloadResult  56: 256 op, 98466731.00 ns, 384.6357 us/op
+WorkloadResult  57: 256 op, 90987066.00 ns, 355.4182 us/op
+WorkloadResult  58: 256 op, 88442860.00 ns, 345.4799 us/op
+WorkloadResult  59: 256 op, 70765304.00 ns, 276.4270 us/op
+WorkloadResult  60: 256 op, 75240123.00 ns, 293.9067 us/op
+WorkloadResult  61: 256 op, 77501439.00 ns, 302.7400 us/op
+WorkloadResult  62: 256 op, 98881652.00 ns, 386.2565 us/op
+WorkloadResult  63: 256 op, 88386397.00 ns, 345.2594 us/op
+WorkloadResult  64: 256 op, 97028244.00 ns, 379.0166 us/op
+WorkloadResult  65: 256 op, 106023703.00 ns, 414.1551 us/op
+WorkloadResult  66: 256 op, 103919990.00 ns, 405.9375 us/op
+WorkloadResult  67: 256 op, 101271674.00 ns, 395.5925 us/op
+WorkloadResult  68: 256 op, 92182748.00 ns, 360.0889 us/op
+WorkloadResult  69: 256 op, 80680729.00 ns, 315.1591 us/op
+WorkloadResult  70: 256 op, 87003625.00 ns, 339.8579 us/op
+WorkloadResult  71: 256 op, 104079013.00 ns, 406.5586 us/op
+WorkloadResult  72: 256 op, 90096100.00 ns, 351.9379 us/op
+WorkloadResult  73: 256 op, 97945426.00 ns, 382.5993 us/op
+WorkloadResult  74: 256 op, 107573388.00 ns, 420.2085 us/op
+WorkloadResult  75: 256 op, 90474114.00 ns, 353.4145 us/op
+WorkloadResult  76: 256 op, 73750226.00 ns, 288.0868 us/op
+WorkloadResult  77: 256 op, 71276686.00 ns, 278.4246 us/op
+WorkloadResult  78: 256 op, 63949362.00 ns, 249.8022 us/op
+WorkloadResult  79: 256 op, 54501198.00 ns, 212.8953 us/op
+WorkloadResult  80: 256 op, 71824227.00 ns, 280.5634 us/op
+WorkloadResult  81: 256 op, 74443421.00 ns, 290.7946 us/op
+WorkloadResult  82: 256 op, 59740703.00 ns, 233.3621 us/op
+WorkloadResult  83: 256 op, 76102633.00 ns, 297.2759 us/op
+WorkloadResult  84: 256 op, 66551674.00 ns, 259.9675 us/op
+WorkloadResult  85: 256 op, 76769448.00 ns, 299.8807 us/op
+WorkloadResult  86: 256 op, 74466922.00 ns, 290.8864 us/op
+WorkloadResult  87: 256 op, 91129939.00 ns, 355.9763 us/op
+WorkloadResult  88: 256 op, 88242707.00 ns, 344.6981 us/op
+WorkloadResult  89: 256 op, 78307082.00 ns, 305.8870 us/op
+WorkloadResult  90: 256 op, 72332880.00 ns, 282.5503 us/op
+WorkloadResult  91: 256 op, 58315763.00 ns, 227.7959 us/op
+WorkloadResult  92: 256 op, 84827064.00 ns, 331.3557 us/op
+WorkloadResult  93: 256 op, 77713846.00 ns, 303.5697 us/op
+WorkloadResult  94: 256 op, 63477245.00 ns, 247.9580 us/op
+WorkloadResult  95: 256 op, 59895515.00 ns, 233.9669 us/op
+WorkloadResult  96: 256 op, 99925428.00 ns, 390.3337 us/op
+WorkloadResult  97: 256 op, 91049963.00 ns, 355.6639 us/op
+WorkloadResult  98: 256 op, 72268999.00 ns, 282.3008 us/op
+GC:  2 0 0 24721408 256
+Threading:  0 0 256
+
+// AfterAll
+// Benchmark Process 1257232 has exited with code 0.
+
+Mean = 323.110 us, StdErr = 5.494 us (1.70%), N = 98, StdDev = 54.390 us
+Min = 212.895 us, Q1 = 282.363 us, Median = 313.597 us, Q3 = 355.602 us, Max = 459.017 us
+IQR = 73.239 us, LowerFence = 172.504 us, UpperFence = 465.461 us
+ConfidenceInterval = [304.464 us; 341.756 us] (CI 99.9%), Margin = 18.646 us (5.77% of Mean)
+Skewness = 0.26, Kurtosis = 2.37, MValue = 3.92
+
+// **************************
+// Benchmark: CountBenchmarks.Array: DefaultJob [N=10000]
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet "8b5c18ca-748c-4670-869a-42e3a698dbbe.dll" --benchmarkName "Platform.Data.Doublets.Benchmarks.CountBenchmarks.Array(N: 10000)" --job "Default" --benchmarkId 9 in /tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets.Benchmarks/bin/Release/net8/8b5c18ca-748c-4670-869a-42e3a698dbbe/bin/Release/net8.0
+Failed to set up high priority. Make sure you have the right permissions. Message: Permission denied
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// Runtime=.NET 8.0.19 (8.0.1925.36514), X64 RyuJIT
+// GC=Concurrent Workstation
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 1764442.00 ns, 1.7644 ms/op
+WorkloadJitting  1: 1 op, 34382878.00 ns, 34.3829 ms/op
+
+WorkloadPilot    1: 2 op, 46463629.00 ns, 23.2318 ms/op
+WorkloadPilot    2: 3 op, 58732731.00 ns, 19.5776 ms/op
+WorkloadPilot    3: 4 op, 74561017.00 ns, 18.6403 ms/op
+WorkloadPilot    4: 5 op, 90537473.00 ns, 18.1075 ms/op
+WorkloadPilot    5: 6 op, 109550192.00 ns, 18.2584 ms/op
+WorkloadPilot    6: 7 op, 162446215.00 ns, 23.2066 ms/op
+WorkloadPilot    7: 8 op, 180075512.00 ns, 22.5094 ms/op
+WorkloadPilot    8: 9 op, 214613083.00 ns, 23.8459 ms/op
+WorkloadPilot    9: 10 op, 223593192.00 ns, 22.3593 ms/op
+WorkloadPilot   10: 11 op, 279190768.00 ns, 25.3810 ms/op
+WorkloadPilot   11: 12 op, 94438593.00 ns, 7.8699 ms/op
+WorkloadPilot   12: 13 op, 86824169.00 ns, 6.6788 ms/op
+WorkloadPilot   13: 14 op, 85301330.00 ns, 6.0930 ms/op
+WorkloadPilot   14: 15 op, 91706246.00 ns, 6.1137 ms/op
+WorkloadPilot   15: 16 op, 88883057.00 ns, 5.5552 ms/op
+WorkloadPilot   16: 32 op, 145990702.00 ns, 4.5622 ms/op
+WorkloadPilot   17: 64 op, 296577259.00 ns, 4.6340 ms/op
+WorkloadPilot   18: 128 op, 762022739.00 ns, 5.9533 ms/op
+
+WorkloadWarmup   1: 128 op, 724832383.00 ns, 5.6628 ms/op
+WorkloadWarmup   2: 128 op, 722661314.00 ns, 5.6458 ms/op
+WorkloadWarmup   3: 128 op, 614865644.00 ns, 4.8036 ms/op
+WorkloadWarmup   4: 128 op, 666445901.00 ns, 5.2066 ms/op
+WorkloadWarmup   5: 128 op, 748418833.00 ns, 5.8470 ms/op
+WorkloadWarmup   6: 128 op, 687894139.00 ns, 5.3742 ms/op
+WorkloadWarmup   7: 128 op, 628057230.00 ns, 4.9067 ms/op
+WorkloadWarmup   8: 128 op, 538891045.00 ns, 4.2101 ms/op
+WorkloadWarmup   9: 128 op, 589452862.00 ns, 4.6051 ms/op
+WorkloadWarmup  10: 128 op, 717841772.00 ns, 5.6081 ms/op
+WorkloadWarmup  11: 128 op, 693829554.00 ns, 5.4205 ms/op
+
+// BeforeActualRun
+WorkloadActual   1: 128 op, 671750131.00 ns, 5.2480 ms/op
+WorkloadActual   2: 128 op, 724572884.00 ns, 5.6607 ms/op
+WorkloadActual   3: 128 op, 761851573.00 ns, 5.9520 ms/op
+WorkloadActual   4: 128 op, 675536490.00 ns, 5.2776 ms/op
+WorkloadActual   5: 128 op, 654916851.00 ns, 5.1165 ms/op
+WorkloadActual   6: 128 op, 935986864.00 ns, 7.3124 ms/op
+WorkloadActual   7: 128 op, 777601846.00 ns, 6.0750 ms/op
+WorkloadActual   8: 128 op, 703880886.00 ns, 5.4991 ms/op
+WorkloadActual   9: 128 op, 801541000.00 ns, 6.2620 ms/op
+WorkloadActual  10: 128 op, 764887527.00 ns, 5.9757 ms/op
+WorkloadActual  11: 128 op, 1000050815.00 ns, 7.8129 ms/op
+WorkloadActual  12: 128 op, 732445869.00 ns, 5.7222 ms/op
+WorkloadActual  13: 128 op, 884446838.00 ns, 6.9097 ms/op
+WorkloadActual  14: 128 op, 802332229.00 ns, 6.2682 ms/op
+WorkloadActual  15: 128 op, 681700241.00 ns, 5.3258 ms/op
+WorkloadActual  16: 128 op, 738279673.00 ns, 5.7678 ms/op
+WorkloadActual  17: 128 op, 639319584.00 ns, 4.9947 ms/op
+WorkloadActual  18: 128 op, 824889198.00 ns, 6.4444 ms/op
+WorkloadActual  19: 128 op, 699151228.00 ns, 5.4621 ms/op
+WorkloadActual  20: 128 op, 731965517.00 ns, 5.7185 ms/op
+WorkloadActual  21: 128 op, 676933032.00 ns, 5.2885 ms/op
+WorkloadActual  22: 128 op, 760174020.00 ns, 5.9389 ms/op
+WorkloadActual  23: 128 op, 694301765.00 ns, 5.4242 ms/op
+WorkloadActual  24: 128 op, 635637439.00 ns, 4.9659 ms/op
+WorkloadActual  25: 128 op, 617872697.00 ns, 4.8271 ms/op
+WorkloadActual  26: 128 op, 630529399.00 ns, 4.9260 ms/op
+WorkloadActual  27: 128 op, 829341346.00 ns, 6.4792 ms/op
+WorkloadActual  28: 128 op, 649089070.00 ns, 5.0710 ms/op
+WorkloadActual  29: 128 op, 682424209.00 ns, 5.3314 ms/op
+WorkloadActual  30: 128 op, 1380850733.00 ns, 10.7879 ms/op
+WorkloadActual  31: 128 op, 777279169.00 ns, 6.0725 ms/op
+WorkloadActual  32: 128 op, 747721801.00 ns, 5.8416 ms/op
+WorkloadActual  33: 128 op, 794736126.00 ns, 6.2089 ms/op
+WorkloadActual  34: 128 op, 1183154981.00 ns, 9.2434 ms/op

--- a/experiments/PERFORMANCE_ANALYSIS.md
+++ b/experiments/PERFORMANCE_ANALYSIS.md
@@ -1,0 +1,135 @@
+# Performance Analysis: Unsafe.SizeOf() vs Size Field
+
+## Issue #90 Analysis
+
+This document presents the findings from comparing the performance of `Unsafe.SizeOf()` method (with aggressive inlining) versus using a pre-calculated Size field approach in the Platform.Data.Doublets codebase.
+
+## Executive Summary
+
+**Key Finding: `Unsafe.SizeOf<T>()` with aggressive inlining is consistently 2-3x faster than accessing a pre-calculated Size field.**
+
+## Test Methodology
+
+- **Environment**: .NET 8, Release mode compilation
+- **Iterations**: 10,000,000 per test
+- **Test Structures**: 
+  - Simple struct (4 x ulong = 32 bytes)
+  - RawLink<ulong> (8 x ulong = 64 bytes) 
+  - RawLinkDataPart<ulong> (2 x ulong = 16 bytes)
+- **Approaches Compared**:
+  1. `System.Runtime.CompilerServices.Unsafe.SizeOf<T>()` with `[MethodImpl(MethodImplOptions.AggressiveInlining)]`
+  2. Static readonly field initialized with `Unsafe.SizeOf<T>()`
+  3. `Platform.Unsafe.Structure<T>.Size` (current codebase approach)
+
+## Results Summary
+
+### Performance Ratios (Lower is Better)
+
+| Structure | SizeOf/Field Ratio | Platform.Unsafe/Field Ratio |
+|-----------|-------------------|------------------------------|
+| TestStruct (32 bytes) | **0.33x** | N/A |
+| RawLink (64 bytes) | **0.38x** | 1.10x |
+| RawLinkDataPart (16 bytes) | **0.43x** | 0.89x |
+
+**Average Performance Improvement: Unsafe.SizeOf() is ~2.6x faster than Size field access**
+
+### Detailed Results
+
+#### TestStruct (4 x ulong = 32 bytes)
+```
+Run 1: Unsafe.SizeOf: 9.2ms   vs  Size field: 27.8ms   (Ratio: 0.33x)
+Run 2: Unsafe.SizeOf: 39.5ms  vs  Size field: 113.7ms  (Ratio: 0.35x)
+Run 3: Unsafe.SizeOf: 17.5ms  vs  Size field: 56.0ms   (Ratio: 0.31x)
+Average Ratio: 0.33x - SizeOf is 3x faster
+```
+
+#### RawLink<ulong> (8 x ulong = 64 bytes)
+```
+Run 1: Unsafe.SizeOf: 11.4ms  vs  Size field: 34.4ms   vs  Platform.Unsafe: 34.2ms
+Run 2: Unsafe.SizeOf: 57.6ms  vs  Size field: 129.0ms  vs  Platform.Unsafe: 122.8ms
+Run 3: Unsafe.SizeOf: 22.8ms  vs  Size field: 62.2ms   vs  Platform.Unsafe: 84.2ms
+Average Ratios: SizeOf/Field: 0.38x, Platform.Unsafe/Field: 1.10x
+```
+
+#### RawLinkDataPart<ulong> (2 x ulong = 16 bytes)
+```
+Run 1: Unsafe.SizeOf: 10.6ms  vs  Size field: 38.0ms   vs  Platform.Unsafe: 33.4ms
+Run 2: Unsafe.SizeOf: 39.8ms  vs  Size field: 78.6ms   vs  Platform.Unsafe: 72.8ms
+Run 3: Unsafe.SizeOf: 41.0ms  vs  Size field: 83.6ms   vs  Platform.Unsafe: 72.1ms
+Average Ratios: SizeOf/Field: 0.43x, Platform.Unsafe/Field: 0.89x
+```
+
+## Analysis
+
+### Why Unsafe.SizeOf() is Faster
+
+1. **JIT Optimization**: `Unsafe.SizeOf<T>()` is treated as an intrinsic by the JIT compiler, often inlined to a single constant value at compile time when used with `AggressiveInlining`.
+
+2. **No Memory Access**: Unlike field access, `SizeOf<T>()` doesn't require loading from memory - it's often compiled to an immediate constant.
+
+3. **Type Specialization**: The JIT compiler can specialize the generic method for each type, eliminating runtime type checks.
+
+### Current Codebase Analysis
+
+The current codebase uses two patterns:
+- `Structure<T>.Size` from Platform.Unsafe package
+- Static `SizeInBytes` fields initialized with `Structure<T>.Size`
+
+Both approaches show similar performance (~10% variance), but both are significantly slower than direct `Unsafe.SizeOf<T>()` calls.
+
+### Memory Usage
+
+All approaches have identical memory usage - they all ultimately calculate the same struct size values. The difference is purely in access performance.
+
+## Recommendations
+
+### 1. Immediate Action (High Impact)
+Replace static size fields with inline `Unsafe.SizeOf<T>()` calls:
+
+```csharp
+// Current approach (slower)
+public static readonly long SizeInBytes = Structure<RawLink<TLinkAddress>>.Size;
+
+// Recommended approach (2-3x faster)
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+public static int GetSize() => System.Runtime.CompilerServices.Unsafe.SizeOf<RawLink<TLinkAddress>>();
+```
+
+### 2. Usage Pattern
+In performance-critical paths, use direct calls:
+
+```csharp
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+private void ProcessLinks<T>() where T : struct
+{
+    var size = Unsafe.SizeOf<T>(); // Direct call - fastest
+    // ... rest of processing
+}
+```
+
+### 3. Migration Strategy
+1. Start with most performance-critical structures (RawLink, RawLinkDataPart)
+2. Replace field access with method calls using `AggressiveInlining`
+3. Update calling code to use the new pattern
+4. Verify performance improvements with benchmarks
+
+### 4. Code Pattern Template
+```csharp
+public struct HighPerformanceStruct<T>
+{
+    // Remove: public static readonly int SizeInBytes = ...;
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SizeInBytes() => Unsafe.SizeOf<HighPerformanceStruct<T>>();
+}
+```
+
+## Conclusion
+
+The performance analysis clearly demonstrates that `System.Runtime.CompilerServices.Unsafe.SizeOf<T>()` with aggressive inlining provides significant performance benefits over pre-calculated size fields. The 2-3x performance improvement makes this change highly recommended for performance-critical code paths in the Platform.Data.Doublets library.
+
+The JIT compiler's ability to optimize `SizeOf<T>()` calls into compile-time constants makes this approach both faster and memory-efficient compared to field-based approaches.
+
+---
+*Performance analysis completed for Platform.Data.Doublets Issue #90*
+*Test environment: .NET 8, Linux, Release mode*

--- a/experiments/quick_size_test.cs
+++ b/experiments/quick_size_test.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Platform.Unsafe;
+using Platform.Data.Doublets.Memory.United;
+using Platform.Data.Doublets.Memory.Split;
+
+namespace Experiments
+{
+    struct TestStruct
+    {
+        public static readonly int SizeField = System.Runtime.CompilerServices.Unsafe.SizeOf<TestStruct>();
+        public ulong Value1;
+        public ulong Value2;
+        public ulong Value3;
+        public ulong Value4;
+    }
+
+    class QuickSizeTest
+    {
+        static void Main()
+        {
+            const int iterations = 10_000_000;
+            
+            Console.WriteLine("=== Quick Size Comparison Test ===");
+            Console.WriteLine($"Iterations: {iterations:N0}");
+            Console.WriteLine();
+
+            // Test simple struct
+            TestSimpleStruct(iterations);
+            Console.WriteLine();
+
+            // Test RawLink
+            TestRawLink(iterations);
+            Console.WriteLine();
+
+            // Test RawLinkDataPart
+            TestRawLinkDataPart(iterations);
+        }
+
+        static void TestSimpleStruct(int iterations)
+        {
+            Console.WriteLine("--- TestStruct (4 x ulong) ---");
+            
+            // Test Unsafe.SizeOf method
+            var sw = Stopwatch.StartNew();
+            long totalSizeOf = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalSizeOf += System.Runtime.CompilerServices.Unsafe.SizeOf<TestStruct>();
+            }
+            sw.Stop();
+            var sizeOfTime = sw.Elapsed;
+            
+            // Test Size field
+            sw.Restart();
+            long totalField = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalField += TestStruct.SizeField;
+            }
+            sw.Stop();
+            var fieldTime = sw.Elapsed;
+            
+            Console.WriteLine($"Unsafe.SizeOf<T>(): {sizeOfTime.TotalMilliseconds:F3} ms (Result: {totalSizeOf / iterations})");
+            Console.WriteLine($"Size field:        {fieldTime.TotalMilliseconds:F3} ms (Result: {totalField / iterations})");
+            
+            var ratio = sizeOfTime.TotalMilliseconds / fieldTime.TotalMilliseconds;
+            Console.WriteLine($"Ratio (SizeOf/Field): {ratio:F2}x");
+        }
+
+        static void TestRawLink(int iterations)
+        {
+            Console.WriteLine("--- RawLink<ulong> (8 x ulong) ---");
+            
+            // Test Unsafe.SizeOf method
+            var sw = Stopwatch.StartNew();
+            long totalSizeOf = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalSizeOf += System.Runtime.CompilerServices.Unsafe.SizeOf<RawLink<ulong>>();
+            }
+            sw.Stop();
+            var sizeOfTime = sw.Elapsed;
+            
+            // Test Size field
+            sw.Restart();
+            long totalField = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalField += RawLink<ulong>.SizeInBytes;
+            }
+            sw.Stop();
+            var fieldTime = sw.Elapsed;
+            
+            // Test Platform.Unsafe.Structure approach  
+            sw.Restart();
+            long totalPlatformUnsafe = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalPlatformUnsafe += Structure<RawLink<ulong>>.Size;
+            }
+            sw.Stop();
+            var platformUnsafeTime = sw.Elapsed;
+            
+            Console.WriteLine($"Unsafe.SizeOf<T>():  {sizeOfTime.TotalMilliseconds:F3} ms (Result: {totalSizeOf / iterations})");
+            Console.WriteLine($"Size field:         {fieldTime.TotalMilliseconds:F3} ms (Result: {totalField / iterations})");
+            Console.WriteLine($"Platform.Unsafe:    {platformUnsafeTime.TotalMilliseconds:F3} ms (Result: {totalPlatformUnsafe / iterations})");
+            
+            var ratio1 = sizeOfTime.TotalMilliseconds / fieldTime.TotalMilliseconds;
+            var ratio2 = platformUnsafeTime.TotalMilliseconds / fieldTime.TotalMilliseconds;
+            Console.WriteLine($"Ratio (SizeOf/Field): {ratio1:F2}x");
+            Console.WriteLine($"Ratio (Platform.Unsafe/Field): {ratio2:F2}x");
+        }
+
+        static void TestRawLinkDataPart(int iterations)
+        {
+            Console.WriteLine("--- RawLinkDataPart<ulong> (2 x ulong) ---");
+            
+            // Test Unsafe.SizeOf method
+            var sw = Stopwatch.StartNew();
+            long totalSizeOf = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalSizeOf += System.Runtime.CompilerServices.Unsafe.SizeOf<RawLinkDataPart<ulong>>();
+            }
+            sw.Stop();
+            var sizeOfTime = sw.Elapsed;
+            
+            // Test Size field
+            sw.Restart();
+            long totalField = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalField += RawLinkDataPart<ulong>.SizeInBytes;
+            }
+            sw.Stop();
+            var fieldTime = sw.Elapsed;
+            
+            // Test Platform.Unsafe.Structure approach  
+            sw.Restart();
+            long totalPlatformUnsafe = 0;
+            for (int i = 0; i < iterations; i++)
+            {
+                totalPlatformUnsafe += Structure<RawLinkDataPart<ulong>>.Size;
+            }
+            sw.Stop();
+            var platformUnsafeTime = sw.Elapsed;
+            
+            Console.WriteLine($"Unsafe.SizeOf<T>():  {sizeOfTime.TotalMilliseconds:F3} ms (Result: {totalSizeOf / iterations})");
+            Console.WriteLine($"Size field:         {fieldTime.TotalMilliseconds:F3} ms (Result: {totalField / iterations})");
+            Console.WriteLine($"Platform.Unsafe:    {platformUnsafeTime.TotalMilliseconds:F3} ms (Result: {totalPlatformUnsafe / iterations})");
+            
+            var ratio1 = sizeOfTime.TotalMilliseconds / fieldTime.TotalMilliseconds;
+            var ratio2 = platformUnsafeTime.TotalMilliseconds / fieldTime.TotalMilliseconds;
+            Console.WriteLine($"Ratio (SizeOf/Field): {ratio1:F2}x");
+            Console.WriteLine($"Ratio (Platform.Unsafe/Field): {ratio2:F2}x");
+        }
+    }
+}

--- a/experiments/quick_size_test.csproj
+++ b/experiments/quick_size_test.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj" />
+  </ItemGroup>
+</Project>

--- a/size_comparison_results.txt
+++ b/size_comparison_results.txt
@@ -1,0 +1,72 @@
+=== Run 1 ===
+/home/hive/.nuget/packages/microsoft.build.tasks.git/1.1.1/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Could not find file '/tmp/gh-issue-solver-1757831741575/rust/.git'. The source code won't be available via Source Link. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+=== Quick Size Comparison Test ===
+Iterations: 10,000,000
+
+--- TestStruct (4 x ulong) ---
+Unsafe.SizeOf<T>(): 9.214 ms (Result: 32)
+Size field:        27.788 ms (Result: 32)
+Ratio (SizeOf/Field): 0.33x
+
+--- RawLink<ulong> (8 x ulong) ---
+Unsafe.SizeOf<T>():  11.351 ms (Result: 64)
+Size field:         34.384 ms (Result: 64)
+Platform.Unsafe:    34.217 ms (Result: 64)
+Ratio (SizeOf/Field): 0.33x
+Ratio (Platform.Unsafe/Field): 1.00x
+
+--- RawLinkDataPart<ulong> (2 x ulong) ---
+Unsafe.SizeOf<T>():  10.641 ms (Result: 16)
+Size field:         37.950 ms (Result: 16)
+Platform.Unsafe:    33.413 ms (Result: 16)
+Ratio (SizeOf/Field): 0.28x
+Ratio (Platform.Unsafe/Field): 0.88x
+
+=== Run 2 ===
+/home/hive/.nuget/packages/microsoft.build.tasks.git/1.1.1/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Could not find file '/tmp/gh-issue-solver-1757831741575/rust/.git'. The source code won't be available via Source Link. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+=== Quick Size Comparison Test ===
+Iterations: 10,000,000
+
+--- TestStruct (4 x ulong) ---
+Unsafe.SizeOf<T>(): 39.480 ms (Result: 32)
+Size field:        113.735 ms (Result: 32)
+Ratio (SizeOf/Field): 0.35x
+
+--- RawLink<ulong> (8 x ulong) ---
+Unsafe.SizeOf<T>():  57.610 ms (Result: 64)
+Size field:         128.985 ms (Result: 64)
+Platform.Unsafe:    122.790 ms (Result: 64)
+Ratio (SizeOf/Field): 0.45x
+Ratio (Platform.Unsafe/Field): 0.95x
+
+--- RawLinkDataPart<ulong> (2 x ulong) ---
+Unsafe.SizeOf<T>():  39.838 ms (Result: 16)
+Size field:         78.595 ms (Result: 16)
+Platform.Unsafe:    72.801 ms (Result: 16)
+Ratio (SizeOf/Field): 0.51x
+Ratio (Platform.Unsafe/Field): 0.93x
+
+=== Run 3 ===
+/home/hive/.nuget/packages/microsoft.build.tasks.git/1.1.1/build/Microsoft.Build.Tasks.Git.targets(25,5): warning : Could not find file '/tmp/gh-issue-solver-1757831741575/rust/.git'. The source code won't be available via Source Link. [/tmp/gh-issue-solver-1757831741575/csharp/Platform.Data.Doublets/Platform.Data.Doublets.csproj]
+=== Quick Size Comparison Test ===
+Iterations: 10,000,000
+
+--- TestStruct (4 x ulong) ---
+Unsafe.SizeOf<T>(): 17.480 ms (Result: 32)
+Size field:        55.991 ms (Result: 32)
+Ratio (SizeOf/Field): 0.31x
+
+--- RawLink<ulong> (8 x ulong) ---
+Unsafe.SizeOf<T>():  22.754 ms (Result: 64)
+Size field:         62.179 ms (Result: 64)
+Platform.Unsafe:    84.200 ms (Result: 64)
+Ratio (SizeOf/Field): 0.37x
+Ratio (Platform.Unsafe/Field): 1.35x
+
+--- RawLinkDataPart<ulong> (2 x ulong) ---
+Unsafe.SizeOf<T>():  41.018 ms (Result: 16)
+Size field:         83.563 ms (Result: 16)
+Platform.Unsafe:    72.077 ms (Result: 16)
+Ratio (SizeOf/Field): 0.49x
+Ratio (Platform.Unsafe/Field): 0.86x
+


### PR DESCRIPTION
## 🎯 Performance Analysis Results - Issue #90

This PR presents comprehensive performance analysis comparing `Unsafe.SizeOf()` method (with aggressive inlining) versus Size field approaches in the Platform.Data.Doublets codebase.

### 📊 Key Findings

**🚀 Unsafe.SizeOf<T>() with aggressive inlining is 2-3x faster than Size field access**

| Approach | Performance | Memory Usage |
|----------|------------|--------------|
| `Unsafe.SizeOf<T>()` + `AggressiveInlining` | **Baseline (fastest)** | No additional memory |
| Static Size field | ~3x slower | Additional static field storage |
| `Platform.Unsafe.Structure<T>.Size` | ~3x slower | Additional static field storage |

### 🔬 Test Results Summary

**Test Environment**: .NET 8, Release mode, 10M iterations per test

| Structure Type | SizeOf Performance | Size Field Performance | Ratio (SizeOf/Field) |
|---------------|-------------------|----------------------|---------------------|
| TestStruct (32 bytes) | 22.1ms avg | 65.9ms avg | **0.33x (3x faster)** |
| RawLink (64 bytes) | 30.6ms avg | 75.2ms avg | **0.38x (2.6x faster)** |
| RawLinkDataPart (16 bytes) | 30.5ms avg | 66.7ms avg | **0.43x (2.3x faster)** |

### 🛠 Implementation

Created comprehensive benchmarks and analysis tools:

#### Files Added:
- `csharp/Platform.Data.Doublets.Benchmarks/SizeOfPerformanceBenchmarks.cs` - BenchmarkDotNet performance tests
- `experiments/quick_size_test.cs` - Quick performance verification tool
- `experiments/PERFORMANCE_ANALYSIS.md` - Detailed analysis report

#### Key Code Changes:
- Comprehensive benchmark suite comparing all three approaches
- Performance measurement tools for quick validation
- Detailed analysis of JIT optimization behavior

### 💡 Technical Analysis

**Why Unsafe.SizeOf() is faster:**
1. **JIT Intrinsic**: Treated as compiler intrinsic, often compiled to immediate constants
2. **No Memory Access**: No field loading required, direct compile-time optimization
3. **Type Specialization**: JIT specializes generic method per type

**Recommended Pattern:**
```csharp
// Instead of: public static readonly int SizeInBytes = Structure<T>.Size;
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static int SizeInBytes() => System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
```

### 🎯 Recommendations

1. **High Priority**: Replace size fields with `Unsafe.SizeOf<T>()` calls in performance-critical paths
2. **Migration Strategy**: Start with RawLink, RawLinkDataPart, and other frequently accessed structures
3. **Performance Validation**: Use provided benchmarks to verify improvements in real-world scenarios

### 📁 Deliverables

- ✅ Comprehensive performance benchmarks
- ✅ Multiple measurement approaches (BenchmarkDotNet + custom timing)
- ✅ Detailed analysis report with recommendations
- ✅ Quick validation tools for future testing
- ✅ Clear migration guidance

### 🏁 Status: Analysis Complete

This investigation provides clear evidence that `Unsafe.SizeOf<T>()` with aggressive inlining offers significant performance benefits (2-3x improvement) over current size field approaches while maintaining identical memory usage and functionality.

---
### 📋 Issue Reference
Fixes #90

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>