### PR TITLE
Implement size-based method to distinguish child tree from thread in AVL balanced trees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/86
+Your prepared branch: issue-86-6c31fd91
+Your prepared working directory: /tmp/gh-issue-solver-1757832738735
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/86
-Your prepared branch: issue-86-6c31fd91
-Your prepared working directory: /tmp/gh-issue-solver-1757832738735
-
-Proceed.

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksAvlBalancedTreeMethodsBase.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksAvlBalancedTreeMethodsBase.cs
@@ -523,6 +523,29 @@ public abstract unsafe class LinksAvlBalancedTreeMethodsBase<TLinkAddress> : Siz
 
     /// <summary>
     ///     <para>
+    ///         Determines whether the left child of a node is a child (not a thread) using size comparison.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    /// <param name="node">
+    ///     <para>The node.</para>
+    ///     <para></para>
+    /// </param>
+    /// <returns>
+    ///     <para>The bool</para>
+    ///     <para></para>
+    /// </returns>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    protected virtual bool GetLeftIsChildBySizeComparison(TLinkAddress node)
+    {
+        var nodeSize = GetSize(node);
+        var left = GetLeft(node);
+        var leftSize = GetSizeOrZero(left);
+        return leftSize > TLinkAddress.Zero && nodeSize > leftSize;
+    }
+
+    /// <summary>
+    ///     <para>
     ///         Sets the left is child value using the specified stored value.
     ///     </para>
     ///     <para></para>
@@ -565,6 +588,29 @@ public abstract unsafe class LinksAvlBalancedTreeMethodsBase<TLinkAddress> : Siz
     {
         return _addressToBoolConverter.Convert(source: Bit<TLinkAddress>.PartialRead(target: value, shift: 3, limit: 1));
         //return Bit<TLinkAddress>.PartialRead(value !=  3, 1, default);
+    }
+
+    /// <summary>
+    ///     <para>
+    ///         Determines whether the right child of a node is a child (not a thread) using size comparison.
+    ///     </para>
+    ///     <para></para>
+    /// </summary>
+    /// <param name="node">
+    ///     <para>The node.</para>
+    ///     <para></para>
+    /// </param>
+    /// <returns>
+    ///     <para>The bool</para>
+    ///     <para></para>
+    /// </returns>
+    [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+    protected virtual bool GetRightIsChildBySizeComparison(TLinkAddress node)
+    {
+        var nodeSize = GetSize(node);
+        var right = GetRight(node);
+        var rightSize = GetSizeOrZero(right);
+        return rightSize > TLinkAddress.Zero && nodeSize > rightSize;
     }
 
     /// <summary>

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSourcesAvlBalancedTreeMethods.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksSourcesAvlBalancedTreeMethods.cs
@@ -173,7 +173,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
 
         /// <summary>
         /// <para>
-        /// Determines whether this instance get left is child.
+        /// Determines whether this instance get left is child using size comparison.
         /// </para>
         /// <para></para>
         /// </summary>
@@ -186,7 +186,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected override bool GetLeftIsChild(TLinkAddress node) => GetLeftIsChildValue(GetLinkReference(node).SizeAsSource);
+        protected override bool GetLeftIsChild(TLinkAddress node) => GetLeftIsChildBySizeComparison(node);
 
         /// <summary>
         /// <para>
@@ -207,7 +207,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
 
         /// <summary>
         /// <para>
-        /// Determines whether this instance get right is child.
+        /// Determines whether this instance get right is child using size comparison.
         /// </para>
         /// <para></para>
         /// </summary>
@@ -220,7 +220,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected override bool GetRightIsChild(TLinkAddress node) => GetRightIsChildValue(GetLinkReference(node).SizeAsSource);
+        protected override bool GetRightIsChild(TLinkAddress node) => GetRightIsChildBySizeComparison(node);
 
         /// <summary>
         /// <para>

--- a/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksTargetsAvlBalancedTreeMethods.cs
+++ b/csharp/Platform.Data.Doublets/Memory/United/Generic/LinksTargetsAvlBalancedTreeMethods.cs
@@ -173,7 +173,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
 
         /// <summary>
         /// <para>
-        /// Determines whether this instance get left is child.
+        /// Determines whether this instance get left is child using size comparison.
         /// </para>
         /// <para></para>
         /// </summary>
@@ -186,7 +186,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected override bool GetLeftIsChild(TLinkAddress node) => GetLeftIsChildValue(GetLinkReference(node).SizeAsTarget);
+        protected override bool GetLeftIsChild(TLinkAddress node) => GetLeftIsChildBySizeComparison(node);
 
         /// <summary>
         /// <para>
@@ -207,7 +207,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
 
         /// <summary>
         /// <para>
-        /// Determines whether this instance get right is child.
+        /// Determines whether this instance get right is child using size comparison.
         /// </para>
         /// <para></para>
         /// </summary>
@@ -220,7 +220,7 @@ namespace Platform.Data.Doublets.Memory.United.Generic
         /// <para></para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected override bool GetRightIsChild(TLinkAddress node) => GetRightIsChildValue(GetLinkReference(node).SizeAsTarget);
+        protected override bool GetRightIsChild(TLinkAddress node) => GetRightIsChildBySizeComparison(node);
 
         /// <summary>
         /// <para>


### PR DESCRIPTION
## 🎯 Summary

This PR implements a different approach to distinguish between child tree and thread relationships in AVL balanced trees, as requested in [issue #86](https://github.com/linksplatform/Data.Doublets/issues/86).

## 🔄 Changes Made

Instead of using bitwise operations on packed values, the new implementation uses **size comparison** which is more intuitive and aligns with the natural properties of AVL trees where a parent's subtree size is always larger than its children's subtree sizes.

### Key Changes:

1. **Added new methods** in `LinksAvlBalancedTreeMethodsBase.cs`:
   - `GetLeftIsChildBySizeComparison(TLinkAddress node)`
   - `GetRightIsChildBySizeComparison(TLinkAddress node)`

2. **Modified concrete implementations** to use size-based comparison:
   - `LinksTargetsAvlBalancedTreeMethods.cs` - Updated `GetLeftIsChild` and `GetRightIsChild` methods  
   - `LinksSourcesAvlBalancedTreeMethods.cs` - Updated `GetLeftIsChild` and `GetRightIsChild` methods

### Implementation Logic:

The new approach uses the following logic:
```csharp
// For left child detection
var nodeSize = GetSize(node);
var left = GetLeft(node);
var leftSize = GetSizeOrZero(left);
return leftSize > TLinkAddress.Zero && nodeSize > leftSize;

// For right child detection  
var nodeSize = GetSize(node);
var right = GetRight(node);
var rightSize = GetSizeOrZero(right);
return rightSize > TLinkAddress.Zero && nodeSize > rightSize;
```

This replaces the previous bitwise operations:
```csharp
// Old approach
return _addressToBoolConverter.Convert(source: Bit<TLinkAddress>.PartialRead(target: value, shift: 4, limit: 1));
```

## ✅ Testing

- ✅ Project builds successfully without compilation errors
- ✅ All existing tests pass
- ✅ No regressions detected
- ✅ Maintains backward compatibility

## 💡 Benefits

1. **More Intuitive**: Uses natural AVL tree properties instead of bit manipulation
2. **Readable**: The logic is self-documenting and easier to understand
3. **Maintainable**: Reduces complexity compared to bitwise operations
4. **Correct**: Leverages the fundamental property that parent nodes always have larger subtree sizes than their children

## 🔗 Related

- Fixes #86
- Addresses the TODO comments in the original codebase that suggested exploring size-based comparison

---

🤖 Generated with [Claude Code](https://claude.ai/code)