### PR TITLE
Add performance comparison tests for dynamic vs generic operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/68
-Your prepared branch: issue-68-4e596e00
-Your prepared working directory: /tmp/gh-issue-solver-1757835486388
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets/issues/68
+Your prepared branch: issue-68-4e596e00
+Your prepared working directory: /tmp/gh-issue-solver-1757835486388
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Benchmarks/DynamicVsGenericBenchmarks.cs
+++ b/csharp/Platform.Data.Doublets.Benchmarks/DynamicVsGenericBenchmarks.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace Platform.Data.Doublets.Benchmarks
+{
+    /// <summary>
+    /// Performance comparison between different approaches for generic operations.
+    /// Based on https://stackoverflow.com/a/8122675/710069
+    /// </summary>
+    [SimpleJob]
+    [MemoryDiagnoser]
+    public class DynamicVsGenericBenchmarks
+    {
+        private const int Iterations = 1000;
+        private readonly ulong[] _values;
+
+        public DynamicVsGenericBenchmarks()
+        {
+            _values = new ulong[Iterations];
+            var random = new System.Random(42);
+            for (int i = 0; i < Iterations; i++)
+            {
+                _values[i] = (ulong)random.Next(1, 100);
+            }
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Warm up expression compilation
+            ExpressionAdd(1UL, 2UL);
+            ExpressionEquals(1UL, 2UL);
+        }
+
+        [Benchmark(Description = "INumber Addition")]
+        public ulong INumberAddition()
+        {
+            ulong sum = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                sum += INumberAdd(_values[i], _values[i + 1]);
+            }
+            return sum;
+        }
+
+        [Benchmark(Description = "Dynamic Addition")]
+        public ulong DynamicAddition()
+        {
+            ulong sum = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                sum += DynamicAdd(_values[i], _values[i + 1]);
+            }
+            return sum;
+        }
+
+        [Benchmark(Description = "Expression Addition")]
+        public ulong ExpressionAddition()
+        {
+            ulong sum = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                sum += ExpressionAdd(_values[i], _values[i + 1]);
+            }
+            return sum;
+        }
+
+        [Benchmark(Description = "IEqualityOperators Equality")]
+        public int IEqualityOperatorsEquality()
+        {
+            int equalCount = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                if (IEqualityOperatorsEquals(_values[i], _values[i + 1]))
+                    equalCount++;
+            }
+            return equalCount;
+        }
+
+        [Benchmark(Description = "EqualityComparer Equality")]
+        public int EqualityComparerEquality()
+        {
+            int equalCount = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                if (EqualityComparerEquals(_values[i], _values[i + 1]))
+                    equalCount++;
+            }
+            return equalCount;
+        }
+
+        [Benchmark(Description = "Dynamic Equality")]
+        public int DynamicEquality()
+        {
+            int equalCount = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                if (DynamicEquals(_values[i], _values[i + 1]))
+                    equalCount++;
+            }
+            return equalCount;
+        }
+
+        [Benchmark(Description = "Expression Equality")]
+        public int ExpressionEquality()
+        {
+            int equalCount = 0;
+            for (int i = 0; i < Iterations - 1; i++)
+            {
+                if (ExpressionEquals(_values[i], _values[i + 1]))
+                    equalCount++;
+            }
+            return equalCount;
+        }
+
+        // Implementation methods
+
+        // INumber approach (NET 7+ - best performance)
+        private static T INumberAdd<T>(T a, T b) where T : INumber<T>
+        {
+            return a + b;
+        }
+
+        // Dynamic approach (slowest)
+        private static T DynamicAdd<T>(T a, T b)
+        {
+            dynamic dynamicA = a;
+            dynamic dynamicB = b;
+            dynamic result = dynamicA + dynamicB;
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        // Expression-based approach (moderate performance)
+        private static readonly ConcurrentDictionary<Type, object> _addFunctions = 
+            new ConcurrentDictionary<Type, object>();
+
+        private static T ExpressionAdd<T>(T a, T b)
+        {
+            var addFunc = (Func<T, T, T>)_addFunctions.GetOrAdd(typeof(T), type =>
+            {
+                var paramA = Expression.Parameter(type, "a");
+                var paramB = Expression.Parameter(type, "b");
+                
+                Expression left = paramA;
+                Expression right = paramB;
+                
+                // For byte and other smaller types, convert to int for arithmetic
+                if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort))
+                {
+                    left = Expression.Convert(paramA, typeof(int));
+                    right = Expression.Convert(paramB, typeof(int));
+                }
+                
+                Expression body = Expression.Add(left, right);
+                
+                // Convert back if needed
+                if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort))
+                {
+                    body = Expression.Convert(body, type);
+                }
+                
+                return Expression.Lambda<Func<T, T, T>>(body, paramA, paramB).Compile();
+            });
+
+            return addFunc(a, b);
+        }
+
+        // IEqualityOperators approach (NET 7+ - best performance)
+        private static bool IEqualityOperatorsEquals<T>(T a, T b) where T : IEqualityOperators<T, T, bool>
+        {
+            return a == b;
+        }
+
+        // EqualityComparer approach (good performance)
+        private static bool EqualityComparerEquals<T>(T a, T b)
+        {
+            return EqualityComparer<T>.Default.Equals(a, b);
+        }
+
+        // Dynamic approach (slowest)
+        private static bool DynamicEquals<T>(T a, T b)
+        {
+            dynamic dynamicA = a;
+            dynamic dynamicB = b;
+            return (bool)(dynamicA == dynamicB);
+        }
+
+        // Expression-based approach (moderate performance)
+        private static readonly ConcurrentDictionary<Type, object> _equalityFunctions = 
+            new ConcurrentDictionary<Type, object>();
+
+        private static bool ExpressionEquals<T>(T a, T b)
+        {
+            var equalityFunc = (Func<T, T, bool>)_equalityFunctions.GetOrAdd(typeof(T), type =>
+            {
+                var paramA = Expression.Parameter(type, "a");
+                var paramB = Expression.Parameter(type, "b");
+                var body = Expression.Equal(paramA, paramB);
+                return Expression.Lambda<Func<T, T, bool>>(body, paramA, paramB).Compile();
+            });
+
+            return equalityFunc(a, b);
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Benchmarks/Program.cs
+++ b/csharp/Platform.Data.Doublets.Benchmarks/Program.cs
@@ -8,6 +8,7 @@ namespace Platform.Data.Doublets.Benchmarks
         {
             BenchmarkRunner.Run<CountBenchmarks>();
             BenchmarkRunner.Run<LinkStructBenchmarks>();
+            BenchmarkRunner.Run<DynamicVsGenericBenchmarks>();
             // BenchmarkRunner.Run<MemoryBenchmarks>();
         }
     }

--- a/csharp/Platform.Data.Doublets.Tests/ComparisonTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/ComparisonTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Numerics;
+using System.Linq.Expressions;
+using Xunit;
+using Platform.Converters;
+
+namespace Platform.Data.Doublets.Tests
+{
+    public static class ComparisonTests
+    {
+        [Fact]
+        public static void GenericAdditionTest()
+        {
+            // Test INumber approach (NET 7+) - recommended approach
+            TestINumberAddition<byte>();
+            TestINumberAddition<ushort>();
+            TestINumberAddition<uint>();
+            TestINumberAddition<ulong>();
+
+            // Test dynamic approach - for comparison
+            TestDynamicAddition<byte>();
+            TestDynamicAddition<ushort>();
+            TestDynamicAddition<uint>();
+            TestDynamicAddition<ulong>();
+
+            // Test expression-based approach
+            TestExpressionAddition<byte>();
+            TestExpressionAddition<ushort>();
+            TestExpressionAddition<uint>();
+            TestExpressionAddition<ulong>();
+        }
+
+        private static void TestINumberAddition<T>() where T : INumber<T>
+        {
+            var a = T.One;
+            var b = T.One;
+            var result = INumberAdd(a, b);
+            var expected = T.One + T.One;
+            Assert.Equal(expected, result);
+        }
+
+        private static void TestDynamicAddition<T>()
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var result = DynamicAdd(a, b);
+            var expected = GetTwo<T>();
+            Assert.Equal(expected, result);
+        }
+
+        private static void TestExpressionAddition<T>()
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var result = ExpressionAdd(a, b);
+            var expected = GetTwo<T>();
+            Assert.Equal(expected, result);
+        }
+
+        // INumber approach (NET 7+ - best performance)
+        private static T INumberAdd<T>(T a, T b) where T : INumber<T>
+        {
+            return a + b;
+        }
+
+        // Dynamic approach (slowest)
+        private static T DynamicAdd<T>(T a, T b)
+        {
+            dynamic dynamicA = a;
+            dynamic dynamicB = b;
+            dynamic result = dynamicA + dynamicB;
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        // Expression-based approach (moderate performance)
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, object> _addFunctions = 
+            new System.Collections.Concurrent.ConcurrentDictionary<Type, object>();
+
+        private static T ExpressionAdd<T>(T a, T b)
+        {
+            var addFunc = (Func<T, T, T>)_addFunctions.GetOrAdd(typeof(T), type =>
+            {
+                var paramA = Expression.Parameter(type, "a");
+                var paramB = Expression.Parameter(type, "b");
+                
+                Expression left = paramA;
+                Expression right = paramB;
+                
+                // For byte and other smaller types, convert to int for arithmetic
+                if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort))
+                {
+                    left = Expression.Convert(paramA, typeof(int));
+                    right = Expression.Convert(paramB, typeof(int));
+                }
+                
+                Expression body = Expression.Add(left, right);
+                
+                // Convert back if needed
+                if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(short) || type == typeof(ushort))
+                {
+                    body = Expression.Convert(body, type);
+                }
+                
+                return Expression.Lambda<Func<T, T, T>>(body, paramA, paramB).Compile();
+            });
+
+            return addFunc(a, b);
+        }
+
+        // Helper methods to get typed values without INumber constraint
+        private static T GetOne<T>()
+        {
+            return (T)Convert.ChangeType(1, typeof(T));
+        }
+
+        private static T GetTwo<T>()
+        {
+            return (T)Convert.ChangeType(2, typeof(T));
+        }
+    }
+}

--- a/csharp/Platform.Data.Doublets.Tests/EqualityTests.cs
+++ b/csharp/Platform.Data.Doublets.Tests/EqualityTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Platform.Data.Doublets.Tests
+{
+    public static class EqualityTests
+    {
+        [Fact]
+        public static void GenericEqualityTest()
+        {
+            // Test IEqualityOperators approach (NET 7+) - recommended approach
+            TestIEqualityOperatorsComparison<byte>();
+            TestIEqualityOperatorsComparison<ushort>();
+            TestIEqualityOperatorsComparison<uint>();
+            TestIEqualityOperatorsComparison<ulong>();
+
+            // Test EqualityComparer approach
+            TestEqualityComparerComparison<byte>();
+            TestEqualityComparerComparison<ushort>();
+            TestEqualityComparerComparison<uint>();
+            TestEqualityComparerComparison<ulong>();
+
+            // Test dynamic approach - for comparison
+            TestDynamicComparison<byte>();
+            TestDynamicComparison<ushort>();
+            TestDynamicComparison<uint>();
+            TestDynamicComparison<ulong>();
+
+            // Test expression-based approach
+            TestExpressionComparison<byte>();
+            TestExpressionComparison<ushort>();
+            TestExpressionComparison<uint>();
+            TestExpressionComparison<ulong>();
+        }
+
+        private static void TestIEqualityOperatorsComparison<T>() where T : IEqualityOperators<T, T, bool>
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var c = GetTwo<T>();
+
+            Assert.True(IEqualityOperatorsEquals(a, b));
+            Assert.False(IEqualityOperatorsEquals(a, c));
+        }
+
+        private static void TestEqualityComparerComparison<T>()
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var c = GetTwo<T>();
+
+            Assert.True(EqualityComparerEquals(a, b));
+            Assert.False(EqualityComparerEquals(a, c));
+        }
+
+        private static void TestDynamicComparison<T>()
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var c = GetTwo<T>();
+
+            Assert.True(DynamicEquals(a, b));
+            Assert.False(DynamicEquals(a, c));
+        }
+
+        private static void TestExpressionComparison<T>()
+        {
+            var a = GetOne<T>();
+            var b = GetOne<T>();
+            var c = GetTwo<T>();
+
+            Assert.True(ExpressionEquals(a, b));
+            Assert.False(ExpressionEquals(a, c));
+        }
+
+        // IEqualityOperators approach (NET 7+ - best performance)
+        private static bool IEqualityOperatorsEquals<T>(T a, T b) where T : IEqualityOperators<T, T, bool>
+        {
+            return a == b;
+        }
+
+        // EqualityComparer approach (good performance)
+        private static bool EqualityComparerEquals<T>(T a, T b)
+        {
+            return EqualityComparer<T>.Default.Equals(a, b);
+        }
+
+        // Dynamic approach (slowest)
+        private static bool DynamicEquals<T>(T a, T b)
+        {
+            dynamic dynamicA = a;
+            dynamic dynamicB = b;
+            return (bool)(dynamicA == dynamicB);
+        }
+
+        // Expression-based approach (moderate performance)
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, object> _equalityFunctions = 
+            new System.Collections.Concurrent.ConcurrentDictionary<Type, object>();
+
+        private static bool ExpressionEquals<T>(T a, T b)
+        {
+            var equalityFunc = (Func<T, T, bool>)_equalityFunctions.GetOrAdd(typeof(T), type =>
+            {
+                var paramA = Expression.Parameter(type, "a");
+                var paramB = Expression.Parameter(type, "b");
+                var body = Expression.Equal(paramA, paramB);
+                return Expression.Lambda<Func<T, T, bool>>(body, paramA, paramB).Compile();
+            });
+
+            return equalityFunc(a, b);
+        }
+
+        // Helper methods to get typed values
+        private static T GetOne<T>()
+        {
+            return (T)Convert.ChangeType(1, typeof(T));
+        }
+
+        private static T GetTwo<T>()
+        {
+            return (T)Convert.ChangeType(2, typeof(T));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements performance comparison tests and benchmarks to measure the performance difference between dynamic operations and other generic approaches, as requested in issue #68.

## Implementation Details

### Added Files
- **`ComparisonTests.cs`**: Unit tests comparing different generic addition approaches
- **`EqualityTests.cs`**: Unit tests comparing different generic equality approaches  
- **`DynamicVsGenericBenchmarks.cs`**: Performance benchmarks using BenchmarkDotNet

### Performance Approaches Compared

Based on the StackOverflow solution referenced in the issue (https://stackoverflow.com/a/8122675/710069):

1. **INumber<T> approach** (NET 7+ - best performance)
   - Uses the new .NET 7+ generic math interfaces
   - Provides compile-time type safety and best runtime performance

2. **EqualityComparer approach** (good performance)
   - Uses `EqualityComparer<T>.Default` for equality comparisons
   - Well-optimized standard approach

3. **Expression-based approach** (moderate performance)
   - Compiles expressions at runtime and caches them
   - Good balance between flexibility and performance

4. **Dynamic approach** (slowest performance)
   - Uses C#'s dynamic keyword for operations
   - Most flexible but with significant performance overhead

### Test Results

All tests pass successfully:
- ✅ ComparisonTests: Tests addition operations across all approaches
- ✅ EqualityTests: Tests equality operations across all approaches
- ✅ All existing tests continue to pass

### Benchmark Usage

To run the performance benchmarks:
```bash
cd csharp/Platform.Data.Doublets.Benchmarks
dotnet run -c Release
```

The benchmarks will show the actual performance differences between:
- INumber addition vs Dynamic addition vs Expression addition
- IEqualityOperators equality vs Dynamic equality vs Expression equality vs EqualityComparer

## Test plan
- [x] Unit tests created and passing
- [x] Benchmarks compile successfully 
- [x] All existing tests continue to pass
- [x] Code follows project conventions

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #68