### PR TITLE
Fix confusing code in DeleteAll()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-354-90a219e1
+Your prepared working directory: /tmp/gh-issue-solver-1761797615725
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-354-90a219e1
-Your prepared working directory: /tmp/gh-issue-solver-1761797615725
-
-Proceed.

--- a/csharp/Platform.Data.Doublets/ILinksExtensions.cs
+++ b/csharp/Platform.Data.Doublets/ILinksExtensions.cs
@@ -164,13 +164,9 @@ namespace Platform.Data.Doublets
         public static void DeleteAll<TLinkAddress>(this ILinks<TLinkAddress> links)  where TLinkAddress : IUnsignedNumber<TLinkAddress>
         {
             var comparer = Comparer<TLinkAddress>.Default;
-            for (var i = links.Count(); comparer.Compare(i, default) > 0; i = --i)
+            for (var i = links.Count(); comparer.Compare(i, default) > 0; i = links.Count())
             {
                 links.Delete(i);
-                if (links.Count() !=  --i)
-                {
-                    i = links.Count();
-                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #354 by simplifying the confusing implementation of the `DeleteAll()` method in `ILinksExtensions.cs`.

### Problem
The original implementation had confusing logic:
```csharp
for (var i = links.Count(); comparer.Compare(i, default) > 0; i = --i)
{
    links.Delete(i);
    if (links.Count() != --i)
    {
        i = links.Count();
    }
}
```

Issues with the old code:
- Used redundant `i = --i` in the for loop increment
- Had a confusing condition `if (links.Count() != --i)` that decremented `i` again
- The logic was hard to understand and maintain

### Solution
Simplified to a much clearer implementation:
```csharp
for (var i = links.Count(); comparer.Compare(i, default) > 0; i = links.Count())
{
    links.Delete(i);
}
```

The new logic is straightforward:
1. Start from the last link (count)
2. Delete it
3. Reset `i` to the new count (which is now one less)
4. Continue until no links remain

### Testing
- All existing tests pass (20 passed, 1 skipped)
- Local build completed successfully
- CI checks passed

### Related Issue
Fixes #354

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)